### PR TITLE
(catalyst blog): Add timeToRead

### DIFF
--- a/themes/gatsby-theme-catalyst-blog/gatsby-node.js
+++ b/themes/gatsby-theme-catalyst-blog/gatsby-node.js
@@ -74,7 +74,8 @@ exports.createSchemaCustomization = ({ actions, schema }, themeOptions) => {
       keywords: [String]!
       excerpt: String!
       draft: Boolean! @defaultFalse
-      featuredImage: File! @fileByRelativePath 
+      featuredImage: File! @fileByRelativePath
+      timeToRead: Int!
   }`)
 
   createTypes(
@@ -118,6 +119,10 @@ exports.createSchemaCustomization = ({ actions, schema }, themeOptions) => {
         body: {
           type: `String!`,
           resolve: mdxResolverPassthrough(`body`),
+        },
+        timeToRead: {
+          type: `Int!`,
+          resolve: mdxResolverPassthrough(`timeToRead`),
         },
       },
       interfaces: [`Node`, `CatalystPost`],

--- a/themes/gatsby-theme-catalyst-blog/src/components/post-list.js
+++ b/themes/gatsby-theme-catalyst-blog/src/components/post-list.js
@@ -8,34 +8,42 @@ import PostListImage from "./post-list/post-list-image"
 import PostListMeta from "./post-list/post-list-meta"
 import PostListExcerpt from "./post-list/post-list-excerpt"
 import PostListReadmore from "./post-list/post-list-readmore"
+import { FaRegClock } from "react-icons/fa"
 
 const PostsList = ({ posts }) => {
   return (
     <Layout>
       <PostListContainer>
         <SEO title="Blog" />
-        {posts.map(({ node }) => {
-          const title = node.title || node.slug
+        {posts.map(post => {
+          const title = post.title || post.slug
           return (
-            <PostListWrapper key={node.slug}>
+            <PostListWrapper key={post.slug}>
               <PostListImage
-                link={node.slug}
-                image={node.featuredImage.childImageSharp.fluid}
-                altText={node.title}
+                link={post.slug}
+                image={post.featuredImage.childImageSharp.fluid}
+                altText={post.title}
               />
               <PostListMeta>
                 <a
-                  href={node.authorLink}
+                  href={post.authorLink}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  {node.author}
+                  {post.author}
                 </a>{" "}
-                &bull; {node.date}
+                &bull; {post.date} &bull;{" "}
+                <FaRegClock
+                  sx={{
+                    position: "relative",
+                    top: "0.125em",
+                  }}
+                />{" "}
+                {post.timeToRead} Min
               </PostListMeta>
-              <PostListTitle link={node.slug}>{title}</PostListTitle>
-              <PostListExcerpt>{node.excerpt}</PostListExcerpt>
-              <PostListReadmore link={node.slug}>Read more</PostListReadmore>
+              <PostListTitle link={post.slug}>{title}</PostListTitle>
+              <PostListExcerpt>{post.excerpt}</PostListExcerpt>
+              <PostListReadmore link={post.slug}>Read more</PostListReadmore>
             </PostListWrapper>
           )
         })}

--- a/themes/gatsby-theme-catalyst-blog/src/components/post.js
+++ b/themes/gatsby-theme-catalyst-blog/src/components/post.js
@@ -7,6 +7,7 @@ import PostTitle from "./post/post-title"
 import PostMeta from "./post/post-meta"
 import PostImage from "./post/post-image"
 import PostFooter from "./post/post-footer"
+import { FaRegClock } from "react-icons/fa"
 
 const Post = ({ data: { post }, previous, next }) => (
   <Layout>
@@ -25,7 +26,14 @@ const Post = ({ data: { post }, previous, next }) => (
         <a href={post.authorLink} target="_blank" rel="noopener noreferrer">
           {post.author}
         </a>{" "}
-        &bull; {post.date}
+        &bull; {post.date} &bull;{" "}
+        <FaRegClock
+          sx={{
+            position: "relative",
+            top: "0.125em",
+          }}
+        />{" "}
+        {post.timeToRead} Min
       </PostMeta>
       <PostTitle>{post.title}</PostTitle>
       <MDXRenderer>{post.body}</MDXRenderer>

--- a/themes/gatsby-theme-catalyst-blog/src/templates/post-query.js
+++ b/themes/gatsby-theme-catalyst-blog/src/templates/post-query.js
@@ -25,6 +25,7 @@ export const query = graphql`
       authorLink
       tags
       keywords
+      timeToRead
       date(formatString: "MMMM DD, YYYY")
       featuredImage {
         childImageSharp {

--- a/themes/gatsby-theme-catalyst-blog/src/templates/posts-query.js
+++ b/themes/gatsby-theme-catalyst-blog/src/templates/posts-query.js
@@ -4,7 +4,7 @@ import PostList from "../components/post-list"
 
 export default ({ data }) => {
   const { allCatalystPost } = data
-  return <PostList posts={allCatalystPost.edges} />
+  return <PostList posts={allCatalystPost.nodes} />
 }
 
 export const query = graphql`
@@ -14,21 +14,20 @@ export const query = graphql`
       limit: 1000
       filter: { draft: { eq: false } }
     ) {
-      edges {
-        node {
-          id
-          excerpt
-          slug
-          title
-          author
-          authorLink
-          date(formatString: "MMMM DD, YYYY")
-          tags
-          featuredImage {
-            childImageSharp {
-              fluid(maxWidth: 1440) {
-                ...GatsbyImageSharpFluid
-              }
+      nodes {
+        id
+        excerpt
+        slug
+        title
+        author
+        authorLink
+        date(formatString: "MMMM DD, YYYY")
+        tags
+        timeToRead
+        featuredImage {
+          childImageSharp {
+            fluid(maxWidth: 1440) {
+              ...GatsbyImageSharpFluid
             }
           }
         }


### PR DESCRIPTION
 - Added in timeToRead using [gatsby-remark-reading-time](https://www.gatsbyjs.org/packages/gatsby-remark-reading-time/)
- Updated posts query to use `nodes` instead of `edges->node`. If you were shadowing this may be breaking, all you would need to do is update your shadowed component.