### PR TITLE
(all): Remove hashSpy on achor links

### DIFF
--- a/themes/gatsby-theme-catalyst-header-side/src/components/navbar/nav-links-anchorlink.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/navbar/nav-links-anchorlink.js
@@ -23,7 +23,6 @@ const NavMenuAnchorLink = ({ link, children }) => {
       to={link.replace(/#/g, "").toLowerCase()}
       onClick={() => setIsNavOpen(false)}
       spy={true}
-      hashSpy={true}
       smooth={true}
       activeClass="active"
       duration={500}

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-anchorlink.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-anchorlink.js
@@ -23,7 +23,6 @@ const NavMenuAnchorLink = ({ link, children }) => {
       to={link.replace(/#/g, "").toLowerCase()}
       onClick={() => setIsNavOpen(false)}
       spy={true}
-      hashSpy={true}
       smooth={true}
       activeClass="active"
       duration={500}


### PR DESCRIPTION
- Fixes a bug where you needed to press the back button a lot on a single page use of these themes. hashSpy was updating the browser history.