### PR TITLE
add prop-shop and example propType with description

### DIFF
--- a/themes/gatsby-theme-catalyst-core/gatsby-config.js
+++ b/themes/gatsby-theme-catalyst-core/gatsby-config.js
@@ -93,6 +93,12 @@ module.exports = options => {
       `gatsby-plugin-sharp`,
       `gatsby-plugin-theme-ui`,
       `gatsby-plugin-offline`,
+      {
+        resolve: `@pauliescanlon/gatsby-plugin-prop-shop`,
+        options: {
+          source: [`${__dirname}/src/components`],
+        },
+      },
     ],
   }
 }

--- a/themes/gatsby-theme-catalyst-core/package.json
+++ b/themes/gatsby-theme-catalyst-core/package.json
@@ -7,6 +7,7 @@
     "@mdx-js/mdx": "^1.5.5",
     "@mdx-js/react": "^1.5.5",
     "@pauliescanlon/gatsby-mdx-embed": "^0.0.17",
+    "@pauliescanlon/gatsby-plugin-prop-shop": "^0.0.0-alpha-4",
     "@theme-ui/preset-tailwind": "^0.3.0",
     "@theme-ui/prism": "^0.3.0",
     "deepmerge": "^4.2.2",

--- a/themes/gatsby-theme-catalyst-core/src/components/layout.js
+++ b/themes/gatsby-theme-catalyst-core/src/components/layout.js
@@ -1,4 +1,5 @@
 /** @jsx jsx */
+import PropTypes from "prop-types"
 import { jsx, Styled } from "theme-ui"
 import Normalize from "../utils/normalize-css"
 import SiteContainer from "./site-container"
@@ -27,3 +28,8 @@ const SiteLayout = ({ children }) => {
 }
 
 export default SiteLayout
+
+SiteLayout.propTypes = {
+  /** Children to render */
+  children: PropTypes.element,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,7 +895,7 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/core@^10.0.0":
+"@emotion/core@^10.0.0", "@emotion/core@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.27.tgz#7c3f78be681ab2273f3bf11ca3e2edc4a9dd1fdc"
   integrity sha512-XbD5R36pVbohQMnKfajHv43g8EbN4NHdF6Zh9zg/C0nr0jqwOw3gYnC07Xj3yG43OYSRyrGsoQ5qPwc8ycvLZw==
@@ -2208,6 +2208,16 @@
   resolved "https://registry.yarnpkg.com/@pauliescanlon/gatsby-mdx-embed/-/gatsby-mdx-embed-0.0.17.tgz#ef67ff62b117ccfa9d8e58c0ed520bf6ae5a4db1"
   integrity sha512-thdvpcC7TBD3hEN+6CzJ0Jl7ln37z4XFU+U1vHEHKKGnxntNlajx/4LkIyONGJA9+tCjYaLls+p7h8Cl7A7Z3g==
 
+"@pauliescanlon/gatsby-plugin-prop-shop@^0.0.0-alpha-4":
+  version "0.0.0-alpha-4"
+  resolved "https://registry.yarnpkg.com/@pauliescanlon/gatsby-plugin-prop-shop/-/gatsby-plugin-prop-shop-0.0.0-alpha-4.tgz#d0c45339595bb3cee205fe44efb4b4fbf69052e5"
+  integrity sha512-3ZKWcZ+GtZWbEEoRa8k0yIBKKxq5sHSDYFHRo6e86FNKfy9+jphqvRfQhRydjyAuC9FO9s2qaJu1qsng4n6WBg==
+  dependencies:
+    "@emotion/core" "^10.0.27"
+    "@mdx-js/react" "^1.5.5"
+    gatsby-transformer-react-docgen "^5.0.28"
+    theme-ui "^0.3.1"
+
 "@pieh/friendly-errors-webpack-plugin@1.7.0-chalk-2":
   version "1.7.0-chalk-2"
   resolved "https://registry.yarnpkg.com/@pieh/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.0-chalk-2.tgz#2e9da9d3ade9d18d013333eb408c457d04eabac0"
@@ -3327,6 +3337,11 @@ ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
+
+ast-types@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.2.tgz#df39b677a911a83f3a049644fb74fdded23cea48"
+  integrity sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -4699,7 +4714,7 @@ commander@2.15.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
   integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
 
-commander@^2.11.0, commander@^2.20.0, commander@~2.20.3:
+commander@^2.11.0, commander@^2.19.0, commander@^2.20.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -7656,6 +7671,18 @@ gatsby-telemetry@^1.1.49:
     stack-trace "^0.0.10"
     stack-utils "1.0.2"
     uuid "3.3.3"
+
+gatsby-transformer-react-docgen@^5.0.28:
+  version "5.0.29"
+  resolved "https://registry.yarnpkg.com/gatsby-transformer-react-docgen/-/gatsby-transformer-react-docgen-5.0.29.tgz#fb0f006c1b5823af92040270aa649790484a9150"
+  integrity sha512-GCAbAW2+rNj2y7MMi70dE4B8YAXXj3WmKv+GSi07NAX0RpU+0VkSFWzx8+LPVl4qu6tQ9Q80rtKu8lgRQ4Xtqw==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/runtime" "^7.7.6"
+    "@babel/types" "^7.7.4"
+    ast-types "^0.13.2"
+    common-tags "^1.8.0"
+    react-docgen "^5.0.0-beta.1"
 
 gatsby-transformer-sharp@^2.3.14:
   version "2.3.14"
@@ -10820,6 +10847,11 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
+min-indent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.0.tgz#cfc45c37e9ec0d8f0a0ec3dd4ef7f7c3abe39256"
+  integrity sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=
+
 mini-css-extract-plugin@^0.8.0:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.2.tgz#a875e169beb27c88af77dd962771c9eedc3da161"
@@ -10852,7 +10884,7 @@ minimatch@3.0.3:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -11123,6 +11155,13 @@ node-abi@^2.7.0:
   integrity sha512-9HrZGFVTR5SOu3PZAnAY2hLO36aW1wmA+FDsVkr85BTST32TLCA1H/AEcatVRAsWLyXS3bqUDYCAjq5/QGuSTA==
   dependencies:
     semver "^5.4.1"
+
+node-dir@^0.1.10:
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
+  integrity sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=
+  dependencies:
+    minimatch "^3.0.2"
 
 node-emoji@^1.10.0:
   version "1.10.0"
@@ -13063,6 +13102,20 @@ react-dev-utils@^4.2.3:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
+react-docgen@^5.0.0-beta.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-5.2.1.tgz#4fc0fd35966c83588e628d49f21c9208d93823a1"
+  integrity sha512-3nvsiDKN/KIlgRyHCdkLrm8ajjSMZ4NIHuwYTAdBvQF3O7A2tmCBB3gwTjJ4zXH8aUpIjFwlVIjffzkJHIZ5/Q==
+  dependencies:
+    "@babel/core" "^7.7.5"
+    "@babel/runtime" "^7.7.6"
+    ast-types "^0.13.2"
+    commander "^2.19.0"
+    doctrine "^3.0.0"
+    neo-async "^2.6.1"
+    node-dir "^0.1.10"
+    strip-indent "^3.0.0"
+
 react-dom@^16.12.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
@@ -14956,6 +15009,13 @@ strip-indent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Hey @ehowey Here's that alpha of "Project Prop" i promised.

As you can see, it's now called PropShop 😊

If you spin up `develop:core` then navigate to `http://localhost:8000/prop-shop/` you should see all the PropType information for `.js` files in your core theme.

... there wasn't actually any propTypes added so i've popped one in otherwise the plugin errors.