### PR TITLE
(catalyst-blog): allow timeToRead to be null

### DIFF
--- a/themes/gatsby-theme-catalyst-blog/gatsby-node.js
+++ b/themes/gatsby-theme-catalyst-blog/gatsby-node.js
@@ -75,7 +75,7 @@ exports.createSchemaCustomization = ({ actions, schema }, themeOptions) => {
       excerpt: String!
       draft: Boolean! @defaultFalse
       featuredImage: File! @fileByRelativePath
-      timeToRead: Int!
+      timeToRead: Int
   }`)
 
   createTypes(
@@ -121,7 +121,7 @@ exports.createSchemaCustomization = ({ actions, schema }, themeOptions) => {
           resolve: mdxResolverPassthrough(`body`),
         },
         timeToRead: {
-          type: `Int!`,
+          type: `Int`,
           resolve: mdxResolverPassthrough(`timeToRead`),
         },
       },


### PR DESCRIPTION
- Fixes an error if the timeToRead field returns null