### PR TITLE
(fix): remove isMobile context and state

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The Catalyst series of themes and starters for [GatsbyJS](https://www.gatsbyjs.o
   - [Menu Links](#menu-links)
   - [Social Links](#social-links)
   - [Theme-ui, variants, and design tokens](#theme-ui-variants-and-design-tokens)
+  - [Breakpoints](#breakpoints)
   - [Typography and changing fonts](#typography-and-changing-fonts)
   - [Changing logos and logo sizes](#changing-logos-and-logo-sizes)
   - [Context Providers](#context-providers)
@@ -100,20 +101,19 @@ There are a number of options for the core theme, blog theme, and writer theme t
 
 **Core theme:**
 
-| Option                   | Values                                    | Description                                                                                                                    |
-| ------------------------ | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `contentPath`            | String                                    | Defaults to "content/pages", determines where the pages are created from.                                                      |
-| `assetPath`              | String                                    | Defaults to "content/assets", determines where the page assets like images are located.                                        |
-| `displaySiteLogo`        | true or false                             | Defaults to true, controls whether the logo is displayed                                                                       |
-| `displaySiteLogoMobile`  | true or false                             | Defaults to true, controls whether the logo is displayed at the mobile breakpoint                                              |
-| `displaySiteTitle`       | true or false                             | Defaults to true, controls whether the site title is displayed                                                                 |
-| `displaySiteTitleMobile` | true or false                             | Defaults to true, controls whether the site title is displayed at the mobile breakpoint                                        |
-| `invertLogo`             | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open                                          |
-| `useStickyHeader`        | true or false                             | Defaults to false, controls whether the header is sticky or static                                                             |
-| `useSocialLinks`         | true or false                             | Defaults to true, controls whether the social links are displayed or not                                                       |
-| `useColorMode`           | true or false                             | Defaults to true, controls whether the dark mode toggle is available.                                                          |
-| `mobileMenuBreakpoint`   | String value, e.g. "1024px"               | Defaults to "768px", sets the breakpoint for displaying the mobile menu, works independent of other breakpoints set in ThemeUI |
-| `footerContentLocation`  | String value, "left", "right" or "center" | Defaults to "left", determines the location of the footer content.                                                             |
+| Option                   | Values                                    | Description                                                                             |
+| ------------------------ | ----------------------------------------- | --------------------------------------------------------------------------------------- |
+| `contentPath`            | String                                    | Defaults to "content/pages", determines where the pages are created from.               |
+| `assetPath`              | String                                    | Defaults to "content/assets", determines where the page assets like images are located. |
+| `displaySiteLogo`        | true or false                             | Defaults to true, controls whether the logo is displayed                                |
+| `displaySiteLogoMobile`  | true or false                             | Defaults to true, controls whether the logo is displayed at the mobile breakpoint       |
+| `displaySiteTitle`       | true or false                             | Defaults to true, controls whether the site title is displayed                          |
+| `displaySiteTitleMobile` | true or false                             | Defaults to true, controls whether the site title is displayed at the mobile breakpoint |
+| `invertLogo`             | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open   |
+| `useStickyHeader`        | true or false                             | Defaults to false, controls whether the header is sticky or static                      |
+| `useSocialLinks`         | true or false                             | Defaults to true, controls whether the social links are displayed or not                |
+| `useColorMode`           | true or false                             | Defaults to true, controls whether the dark mode toggle is available.                   |
+| `footerContentLocation`  | String value, "left", "right" or "center" | Defaults to "left", determines the location of the footer content.                      |
 
 **Blog theme:**
 
@@ -244,6 +244,33 @@ variants: {
   },
 ```
 
+### Breakpoints
+
+Breakpoints are set using Theme-UI theme file and default to 480px, 768px, 1024px, and 1440px. The mobile menu is enabled at the 2nd breakpoint, 768px, but you can change this by changing the second breakpoint.
+
+```js
+breakpoints: ["480px", "768px", "1024px", "1440px"],
+```
+
+The array notation is used to target different screen sizes based on the breakpoints set in the theme file. You can use `null`, to inherit the previous value.
+
+```jsx
+<h1
+  sx={{
+    // 0-479px: Red
+    // 480px - 767px: Blue
+    // 768px - 1023px: Yellow
+    // 1024px - 1439px: Yellow
+    // 1440px and up: Pink
+    color: ["red", "blue", "yellow", null, "pink"],
+  }}
+>
+  Breakpoints
+</h1>
+```
+
+[Read more about breakpoints in theme-ui](https://theme-ui.com/theming/#breakpoints)
+
 ### Typography and changing fonts
 
 To add a custom font you need to first add the font as a dependency in your starter site, for example:
@@ -306,11 +333,13 @@ There is also a file called `catalyst-site-icon.png` that provides your icon for
 
 ### Context providers
 
-There are one context provider that is globally available in the themes to manage component function or appearance based on state. This is `isNavOpen`.
+There are two context providers that are globally available in the themes to manage component function or appearance based on state. These are `isNavOpen` and `isHome`.
 
 isNavOpen: True if the mobile nav menu is open
 
-isMobile and isHome are depreciated and will be removed in v1.0. They were depreciated for performance reasons.
+isHome: True if you are on the homepage, this can cause a flash of unstyled content so use with caution.
+
+isMobile is depreciated and will be removed in v1.0. It was depreciated for performance reasons.
 
 ```js
 // Import useContext and the context
@@ -346,6 +375,10 @@ By default Gatsby provides excellent SEO out of the box. I have extended this wi
 ## Migrating
 
 The first place to start is by checking the changelog file. Beginning at release v0.20.0 I have started tracking major changes in there. Other major breaking changes will be commented on here.
+
+**Removal of isMobile Context and mobileMenuBreakpoint**
+
+These are depreciated and will stop working post v1.0. There was a perfomance issue with SSR and javascript that was causing a flash of unstyled content. I have reverted back to using normal media queries for changing to the mobile menu at the second breakpoint, 768px by default.
 
 **gatsby-theme-catalyst-header-basic -> gatsby-theme-catalyst-header-top**
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ There are a number of options for the core theme, blog theme, and writer theme t
 | `useSocialLinks`         | true or false                             | Defaults to true, controls whether the social links are displayed or not                                                       |
 | `useColorMode`           | true or false                             | Defaults to true, controls whether the dark mode toggle is available.                                                          |
 | `mobileMenuBreakpoint`   | String value, e.g. "1024px"               | Defaults to "768px", sets the breakpoint for displaying the mobile menu, works independent of other breakpoints set in ThemeUI |
-| `isHeaderSideLeft`       | true or false                             | Defaults to true, only effects `gatsby-theme-catalyst-header-side, controls whether the header is on the left or right         |
 | `footerContentLocation`  | String value, "left", "right" or "center" | Defaults to "left", determines the location of the footer content.                                                             |
 
 **Blog theme:**

--- a/README.md
+++ b/README.md
@@ -306,34 +306,32 @@ There is also a file called `catalyst-site-icon.png` that provides your icon for
 
 ### Context providers
 
-There are three context providers that are globally available in the themes to manage component function or appearance based on state. These are `isHome`, `isMobile`, and `isNavOpen`.
-
-isHome: True if you are at the root of your site
-
-isMobile: True if the viewport width is smaller than the value set in `mobileBreakpoint` option via theme options
+There are one context provider that is globally available in the themes to manage component function or appearance based on state. This is `isNavOpen`.
 
 isNavOpen: True if the mobile nav menu is open
+
+isMobile and isHome are depreciated and will be removed in v1.0. They were depreciated for performance reasons.
 
 ```js
 // Import useContext and the context
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import { useContext } from "react"
-import { MobileContext } from "gatsby-theme-catalyst-core"
+import { NavContext } from "gatsby-theme-catalyst-core"
 
 const Example = () => {
   // Access the context in your component
-  const [isMobile] = useContext(MobileContext)
+  const [isNavOpen] = useContext(NavContext)
   // Conditionally change css or render components
   return (
     <div
       sx={{
         height: "200px",
         width: "200px",
-        backgroundColor: isMobile ? "red" : "blue",
+        backgroundColor: isNavOpen ? "red" : "blue",
       }}
     >
-      {isMobile && <Component />}
+      {isNavOpen && <Component />}
     </div>
   )
 }

--- a/starters/gatsby-starter-catalyst-basic/gatsby-config.js
+++ b/starters/gatsby-starter-catalyst-basic/gatsby-config.js
@@ -68,7 +68,6 @@ module.exports = {
         // useSocialLinks: true,
         // useColorMode: true,
         // mobileMenuBreakpoint: `768px`,
-        // isHeaderSideLeft: true, // Only effects gatsby-catalyst-header-top
         //footerContentLocation: "left", // "left", "right", "center"
       },
     },

--- a/starters/gatsby-starter-catalyst-basic/src/gatsby-theme-catalyst-core/theme.js
+++ b/starters/gatsby-starter-catalyst-basic/src/gatsby-theme-catalyst-core/theme.js
@@ -132,9 +132,5 @@ export default {
       padding: 2,
     },
   },
-  variants: {
-    siteTitle: {
-      fontSize: [4, null, null, 5, null],
-    },
-  },
+  variants: {},
 }

--- a/starters/gatsby-starter-catalyst-blog/gatsby-config.js
+++ b/starters/gatsby-starter-catalyst-blog/gatsby-config.js
@@ -56,7 +56,6 @@ module.exports = {
         // useSocialLinks: true,
         // useColorMode: true,
         // mobileMenuBreakpoint: `768px`,
-        // isHeaderSideLeft: true, // Only effects gatsby-catalyst-header-top
         //footerContentLocation: "left", // "left", "right", "center"
         useStickyHeader: true,
         footerContentLocation: "center",

--- a/starters/gatsby-starter-catalyst-blog/src/gatsby-theme-catalyst-core/theme.js
+++ b/starters/gatsby-starter-catalyst-blog/src/gatsby-theme-catalyst-core/theme.js
@@ -131,9 +131,6 @@ export default {
     },
   },
   variants: {
-    siteTitle: {
-      fontSize: [4, null, null, 5, null],
-    },
     siteLogo: {
       borderRadius: "9999em",
       mb: 4,

--- a/starters/gatsby-starter-catalyst-core/gatsby-config.js
+++ b/starters/gatsby-starter-catalyst-core/gatsby-config.js
@@ -56,7 +56,6 @@ module.exports = {
         // useSocialLinks: true,
         // useColorMode: true,
         // mobileMenuBreakpoint: `768px`,
-        // isHeaderSideLeft: true, // Only effects gatsby-catalyst-header-top
         //footerContentLocation: "left", // "left", "right", "center"
       },
     },

--- a/starters/gatsby-starter-catalyst-writer/gatsby-config.js
+++ b/starters/gatsby-starter-catalyst-writer/gatsby-config.js
@@ -40,7 +40,6 @@ module.exports = {
         // useSocialLinks: true,
         // useColorMode: true,
         // mobileMenuBreakpoint: `768px`,
-        // isHeaderSideLeft: true, // Only effects gatsby-catalyst-header-top
         //footerContentLocation: "left", // "left", "right", "center"
         displaySiteLogo: false,
         displaySiteLogoMobile: false,

--- a/themes/gatsby-theme-catalyst-core/gatsby-node.js
+++ b/themes/gatsby-theme-catalyst-core/gatsby-node.js
@@ -17,7 +17,6 @@ exports.createSchemaCustomization = ({ actions }) => {
     useStickyHeader: Boolean!
     useSocialLinks: Boolean!
     useColorMode: Boolean!
-    isHeaderSideLeft: Boolean!
     footerContentLocation: String!
   }`)
 }
@@ -37,7 +36,6 @@ exports.sourceNodes = (
     useStickyHeader = false,
     useSocialLinks = true,
     useColorMode = true,
-    isHeaderSideLeft = true,
     footerContentLocation = "left",
   }
 ) => {
@@ -55,7 +53,6 @@ exports.sourceNodes = (
     useStickyHeader,
     useSocialLinks,
     useColorMode,
-    isHeaderSideLeft,
     footerContentLocation,
   }
   createNode({

--- a/themes/gatsby-theme-catalyst-core/src/utils/use-catalyst-config.js
+++ b/themes/gatsby-theme-catalyst-core/src/utils/use-catalyst-config.js
@@ -16,7 +16,6 @@ export const useCatalystConfig = () => {
           useStickyHeader
           useSocialLinks
           useColorMode
-          isHeaderSideLeft
           footerContentLocation
         }
       }

--- a/themes/gatsby-theme-catalyst-header-side/README.md
+++ b/themes/gatsby-theme-catalyst-header-side/README.md
@@ -1,6 +1,6 @@
 # Gatsby Theme Catalyst Header Side
 
-Sibling theme for `gatsby-theme-catalyst-core` which adds a sidebar header using latent component shadowing. Theme options are set set via `gatsby-theme-catalyst-core`, for example setting `isHeaderSideLeft: false` will switch the sidebar to the right hand side.
+Sibling theme for `gatsby-theme-catalyst-core` which adds a sidebar header using latent component shadowing. Header is on the left.
 
 **Additional Documentation**
 

--- a/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding-link-wrapper.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding-link-wrapper.js
@@ -17,6 +17,7 @@ const LinkWrapper = ({ children }) => {
         onKeyPress={scroll.scrollToTop}
         role="button"
         tabIndex="0"
+        aria-label="Scroll to top"
       >
         {children}
       </div>

--- a/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding-logo.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding-logo.js
@@ -2,7 +2,6 @@
 import { jsx } from "theme-ui"
 import Img from "gatsby-image"
 import { useContext } from "react"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import { NavContext } from "gatsby-theme-catalyst-core"
 import { useCatalystConfig } from "gatsby-theme-catalyst-core"
 import { useSiteMetadata } from "gatsby-theme-catalyst-core"
@@ -11,7 +10,6 @@ import LinkWrapper from "./branding-link-wrapper"
 const SiteLogo = () => {
   const { title, logo } = useSiteMetadata()
   const [isNavOpen] = useContext(NavContext)
-  const [isMobile] = useContext(MobileContext)
   const { invertSiteLogo } = useCatalystConfig()
   const invertLogo = () => {
     if (invertSiteLogo) {
@@ -38,7 +36,7 @@ const SiteLogo = () => {
             theme => theme.sizes.logoWidthL,
             theme => theme.sizes.logoWidthXL,
           ],
-          filter: isMobile && isNavOpen ? invertLogo : "none",
+          filter: isNavOpen ? invertLogo : "none",
           variant: "variants.siteLogo",
         }}
         fluid={logo}

--- a/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding-logo.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding-logo.js
@@ -10,10 +10,28 @@ import LinkWrapper from "./branding-link-wrapper"
 const SiteLogo = () => {
   const { title, logo } = useSiteMetadata()
   const [isNavOpen] = useContext(NavContext)
-  const { invertSiteLogo } = useCatalystConfig()
+  const {
+    invertSiteLogo,
+    displaySiteLogo,
+    displaySiteLogoMobile,
+  } = useCatalystConfig()
   const invertLogo = () => {
     if (invertSiteLogo) {
       return "invert(1)"
+    } else {
+      return "none"
+    }
+  }
+  const displayLaptop = () => {
+    if (displaySiteLogo) {
+      return "block"
+    } else {
+      return "none"
+    }
+  }
+  const displayPhone = () => {
+    if (displaySiteLogoMobile) {
+      return "block"
     } else {
       return "none"
     }
@@ -22,6 +40,7 @@ const SiteLogo = () => {
     <LinkWrapper>
       <Img
         sx={{
+          display: [displayPhone, null, displayLaptop, null, null],
           height: [
             theme => theme.sizes.logoHeightXS,
             theme => theme.sizes.logoHeightS,

--- a/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding-title.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding-title.js
@@ -2,21 +2,19 @@
 import { jsx, Styled } from "theme-ui"
 import { useContext } from "react"
 import { useSiteMetadata } from "gatsby-theme-catalyst-core"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import { NavContext } from "gatsby-theme-catalyst-core"
 import LinkWrapper from "./branding-link-wrapper"
 
 const SiteTitle = () => {
   const { title } = useSiteMetadata()
   const [isNavOpen] = useContext(NavContext)
-  const [isMobile] = useContext(MobileContext)
 
   return (
     <LinkWrapper>
       <Styled.h1
         as="span"
         sx={{
-          color: isMobile && isNavOpen ? "header.textOpen" : "header.text",
+          color: isNavOpen ? "header.textOpen" : "header.text",
           fontFamily: "siteTitle",
           whiteSpace: "nowrap",
           flex: "0 0 auto",

--- a/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding-title.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding-title.js
@@ -1,19 +1,40 @@
 /** @jsx jsx */
 import { jsx, Styled } from "theme-ui"
 import { useContext } from "react"
-import { useSiteMetadata } from "gatsby-theme-catalyst-core"
-import { NavContext } from "gatsby-theme-catalyst-core"
+import {
+  useSiteMetadata,
+  NavContext,
+  useCatalystConfig,
+} from "gatsby-theme-catalyst-core"
 import LinkWrapper from "./branding-link-wrapper"
 
 const SiteTitle = () => {
   const { title } = useSiteMetadata()
+  const { displaySiteTitle, displaySiteTitleMobile } = useCatalystConfig()
   const [isNavOpen] = useContext(NavContext)
+
+  const displayLaptop = () => {
+    if (displaySiteTitle) {
+      return "block"
+    } else {
+      return "none"
+    }
+  }
+  const displayPhone = () => {
+    if (displaySiteTitleMobile) {
+      return "block"
+    } else {
+      return "none"
+    }
+  }
 
   return (
     <LinkWrapper>
       <Styled.h1
         as="span"
         sx={{
+          display: [displayPhone, null, displayLaptop, null, null],
+          fontSize: [4, null, null, 5, null],
           color: isNavOpen ? "header.textOpen" : "header.text",
           fontFamily: "siteTitle",
           whiteSpace: "nowrap",

--- a/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding.js
@@ -1,10 +1,8 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import { useContext } from "react"
 import { useCatalystConfig } from "gatsby-theme-catalyst-core"
 import Logo from "./branding-logo"
 import Title from "./branding-title"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 
 const SiteBranding = () => {
   const {
@@ -13,15 +11,14 @@ const SiteBranding = () => {
     displaySiteTitleMobile,
     displaySiteLogoMobile,
   } = useCatalystConfig()
-  const [isMobile] = useContext(MobileContext)
 
   return (
     <div
       sx={{
-        gridColumn: isMobile ? "2 / 3" : "1 / -1",
+        gridColumn: ["2 / 3", null, "1 / -1", null, null],
         gridRow: "1 / 2",
         display: "flex",
-        flexDirection: isMobile ? "row" : "column",
+        flexDirection: ["row", null, "column", null, null],
         alignItems: "center",
         justifyContent: "center",
       }}

--- a/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding.js
@@ -3,8 +3,12 @@ import { jsx } from "theme-ui"
 import { useCatalystConfig } from "gatsby-theme-catalyst-core"
 import Logo from "./branding-logo"
 import Title from "./branding-title"
+import { useContext } from "react"
+import { MobileContext } from "gatsby-theme-catalyst-core"
 
 const SiteBranding = () => {
+  const [isMobile] = useContext(MobileContext)
+
   const {
     displaySiteLogo,
     displaySiteTitle,

--- a/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/branding/branding.js
@@ -1,21 +1,9 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import { useCatalystConfig } from "gatsby-theme-catalyst-core"
 import Logo from "./branding-logo"
 import Title from "./branding-title"
-import { useContext } from "react"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 
 const SiteBranding = () => {
-  const [isMobile] = useContext(MobileContext)
-
-  const {
-    displaySiteLogo,
-    displaySiteTitle,
-    displaySiteTitleMobile,
-    displaySiteLogoMobile,
-  } = useCatalystConfig()
-
   return (
     <div
       sx={{
@@ -27,12 +15,8 @@ const SiteBranding = () => {
         justifyContent: "center",
       }}
     >
-      {isMobile
-        ? displaySiteLogoMobile && <Logo />
-        : displaySiteLogo && <Logo />}
-      {isMobile
-        ? displaySiteTitleMobile && <Title />
-        : displaySiteTitle && <Title />}
+      <Logo />
+      <Title />
     </div>
   )
 }

--- a/themes/gatsby-theme-catalyst-header-side/src/components/header.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/header.js
@@ -5,7 +5,6 @@ import Branding from "./branding/branding"
 import Nav from "./navbar/nav"
 import MobileButton from "./navbar/nav-mobile-button"
 import { NavContext } from "gatsby-theme-catalyst-core"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import { useCatalystConfig } from "gatsby-theme-catalyst-core"
 
 const SiteHeader = () => {

--- a/themes/gatsby-theme-catalyst-header-side/src/components/header.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/header.js
@@ -10,7 +10,6 @@ import { useCatalystConfig } from "gatsby-theme-catalyst-core"
 
 const SiteHeader = () => {
   const [isNavOpen] = useContext(NavContext)
-  const [isMobile] = useContext(MobileContext)
   const { useStickyHeader } = useCatalystConfig()
   return (
     <header
@@ -20,15 +19,12 @@ const SiteHeader = () => {
         top: 0,
         width: "100%",
         height: useStickyHeader
-          ? isMobile
-            ? "auto"
-            : "100vh"
-          : isMobile
-          ? "auto"
-          : "100%",
-        color: isMobile && isNavOpen ? "header.textOpen" : "header.text",
-        backgroundColor:
-          isMobile && isNavOpen ? "header.backgroundOpen" : "header.background",
+          ? ["auto", null, "100vh", null, null]
+          : ["auto", null, "100%", null, null],
+        color: isNavOpen ? "header.textOpen" : "header.text",
+        backgroundColor: isNavOpen
+          ? "header.backgroundOpen"
+          : "header.background",
         gridArea: "header",
         overflowY: "scroll",
         zIndex: "888", // Ensure the header is always on top
@@ -41,10 +37,10 @@ const SiteHeader = () => {
           gridColumn: "1 / -1",
           alignSelf: "start",
           display: "grid",
-          gridTemplateColumns: isMobile ? "60px auto 60px" : "1fr",
-          gridTemplateRows: isMobile ? "auto" : "auto auto",
-          p: isMobile ? 1 : 3,
-          pb: isMobile && isNavOpen ? 4 : 0,
+          gridTemplateColumns: ["60px auto 60px", null, "1fr", null, null],
+          gridTemplateRows: ["auto", null, "auto auto", null, null],
+          p: [1, null, 3, null, null],
+          pb: isNavOpen ? 4 : 0,
         }}
       >
         <Branding />

--- a/themes/gatsby-theme-catalyst-header-side/src/components/navbar/nav-color-button.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/navbar/nav-color-button.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx, useColorMode, useThemeUI, IconButton } from "theme-ui"
 import { useContext } from "react"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import { NavContext } from "gatsby-theme-catalyst-core"
 import { FiSun, FiMoon } from "react-icons/fi"
 import { IconContext } from "react-icons"
@@ -9,7 +8,6 @@ import { IconContext } from "react-icons"
 const ColorModeButton = () => {
   const [colorMode, setColorMode] = useColorMode()
   const [isNavOpen] = useContext(NavContext)
-  const [isMobile] = useContext(MobileContext)
   const { theme } = useThemeUI()
   console.log(colorMode)
 
@@ -19,7 +17,7 @@ const ColorModeButton = () => {
         display: "grid",
         placeItems: "center",
         cursor: "pointer",
-        color: isMobile && isNavOpen ? "header.iconsOpen" : "header.icons",
+        color: isNavOpen ? "header.iconsOpen" : "header.icons",
         width: "auto",
         height: "auto",
         p: 0,

--- a/themes/gatsby-theme-catalyst-header-side/src/components/navbar/nav-color-button.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/navbar/nav-color-button.js
@@ -9,7 +9,6 @@ const ColorModeButton = () => {
   const [colorMode, setColorMode] = useColorMode()
   const [isNavOpen] = useContext(NavContext)
   const { theme } = useThemeUI()
-  console.log(colorMode)
 
   return (
     <IconButton

--- a/themes/gatsby-theme-catalyst-header-side/src/components/navbar/nav-li.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/navbar/nav-li.js
@@ -1,11 +1,9 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import { useContext } from "react"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import { NavContext } from "gatsby-theme-catalyst-core"
 
 const NavLi = ({ children }) => {
-  const [isMobile] = useContext(MobileContext)
   const [isNavOpen] = useContext(NavContext)
 
   return (
@@ -14,7 +12,7 @@ const NavLi = ({ children }) => {
         mb: 3,
         fontFamily: "navLinks",
         a: {
-          color: isMobile && isNavOpen ? "header.textOpen" : "header.text",
+          color: isNavOpen ? "header.textOpen" : "header.text",
           textDecoration: "none",
           py: 1,
           px: 1,

--- a/themes/gatsby-theme-catalyst-header-side/src/components/navbar/nav-mobile-button.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/navbar/nav-mobile-button.js
@@ -2,7 +2,6 @@
 import { jsx } from "theme-ui"
 import { useContext } from "react"
 import { NavContext } from "gatsby-theme-catalyst-core"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 
 const Span = ({ open }) => (
   <span
@@ -36,7 +35,6 @@ const Span = ({ open }) => (
 
 const SiteMobileButton = () => {
   const [isNavOpen, setIsNavOpen] = useContext(NavContext)
-  const [isMobile] = useContext(MobileContext)
   return (
     <button
       aria-label="Toggle Menu"
@@ -45,9 +43,9 @@ const SiteMobileButton = () => {
         gridColumn: "3 / 4",
         gridRow: "1 / 2",
         alignSelf: "center",
-        color: isMobile && isNavOpen ? "header.textOpen" : "header.text",
+        color: isNavOpen ? "header.textOpen" : "header.text",
         cursor: "pointer",
-        display: isMobile ? "block" : "none",
+        display: ["block", null, "none", null, null],
         height: "3rem",
         position: "relative",
         width: "3rem",

--- a/themes/gatsby-theme-catalyst-header-side/src/components/navbar/nav-social.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/navbar/nav-social.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import { useContext } from "react"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import { NavContext } from "gatsby-theme-catalyst-core"
 import { useCatalystConfig } from "gatsby-theme-catalyst-core"
 import { SocialHeader } from "gatsby-theme-catalyst-core"
@@ -9,7 +8,6 @@ import NavColorButton from "./nav-color-button"
 
 const SocialWrapper = () => {
   const [isNavOpen] = useContext(NavContext)
-  const [isMobile] = useContext(MobileContext)
   const { useColorMode } = useCatalystConfig()
 
   return (
@@ -18,7 +16,7 @@ const SocialWrapper = () => {
         mt: 3,
         display: "flex",
         a: {
-          color: isMobile && isNavOpen ? "header.iconsOpen" : "header.icons",
+          color: isNavOpen ? "header.iconsOpen" : "header.icons",
           mr: 2,
           textDecoration: "none",
           display: "grid",

--- a/themes/gatsby-theme-catalyst-header-side/src/components/navbar/nav.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/components/navbar/nav.js
@@ -2,21 +2,19 @@
 import { jsx } from "theme-ui"
 import { useContext } from "react"
 import { NavContext } from "gatsby-theme-catalyst-core"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import NavLinks from "./nav-links"
 import NavSocialLinks from "./nav-social"
 
 const NavLayout = () => {
   const [isNavOpen] = useContext(NavContext)
-  const [isMobile] = useContext(MobileContext)
 
   return (
     <nav
       sx={{
         mt: 4,
-        gridColumn: isMobile ? "1 / -1" : "1 / 1",
+        gridColumn: ["1 / -1", null, "1 / 1", null, null],
         gridRow: "2 / 3",
-        display: isMobile && isNavOpen ? "flex" : isMobile ? "none" : "flex",
+        display: isNavOpen ? "flex" : ["none", null, "flex", null, null],
         flexDirection: "column",
         alignItems: "center",
         textAlign: "center",

--- a/themes/gatsby-theme-catalyst-header-side/src/gatsby-theme-catalyst-core/components/site-container.js
+++ b/themes/gatsby-theme-catalyst-header-side/src/gatsby-theme-catalyst-core/components/site-container.js
@@ -1,40 +1,40 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import { useContext } from "react"
-import { MobileContext } from "gatsby-theme-catalyst-core"
-import { useCatalystConfig } from "gatsby-theme-catalyst-core"
 
 const SiteContainer = ({ children }) => {
-  const [isMobile] = useContext(MobileContext)
-  const { isHeaderSideLeft } = useCatalystConfig()
   return (
     <div
       sx={{
         minHeight: "100vh",
         display: "grid",
-        gridTemplateColumns: isMobile
-          ? "minmax(0, 1fr)"
-          : isHeaderSideLeft
-          ? "auto minmax(0, 1fr)"
-          : "minmax(0, 1fr) auto",
-        gridTemplateRows: isMobile
-          ? "auto minmax(0, 1fr) auto"
-          : "minmax(0, 1fr) auto",
-        gridTemplateAreas: isMobile
-          ? `
+        gridTemplateColumns: [
+          "minmax(0, 1fr)",
+          null,
+          "auto minmax(0, 1fr)",
+          null,
+          null,
+        ],
+        gridTemplateRows: [
+          "auto minmax(0, 1fr) auto",
+          null,
+          "minmax(0, 1fr) auto",
+          null,
+          null,
+        ],
+        gridTemplateAreas: [
+          `
         "header"
         "main"
         "footer"
-        `
-          : isHeaderSideLeft
-          ? `
+        `,
+          null,
+          `
         "header main"
         "header footer"
-        `
-          : `
-        "main header"
-        "footer header"
         `,
+          null,
+          null,
+        ],
         variant: "variants.siteContainer",
       }}
     >

--- a/themes/gatsby-theme-catalyst-header-top/src/components/branding/branding-link-wrapper.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/branding/branding-link-wrapper.js
@@ -17,6 +17,7 @@ const LinkWrapper = ({ children }) => {
         onKeyPress={scroll.scrollToTop}
         role="button"
         tabIndex="0"
+        aria-label="Scroll to top"
       >
         {children}
       </div>

--- a/themes/gatsby-theme-catalyst-header-top/src/components/branding/branding-logo.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/branding/branding-logo.js
@@ -2,7 +2,6 @@
 import { jsx } from "theme-ui"
 import Img from "gatsby-image"
 import { useContext } from "react"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import { NavContext } from "gatsby-theme-catalyst-core"
 import { useCatalystConfig } from "gatsby-theme-catalyst-core"
 import { useSiteMetadata } from "gatsby-theme-catalyst-core"
@@ -11,7 +10,6 @@ import LinkWrapper from "./branding-link-wrapper"
 const SiteLogo = () => {
   const { title, logo } = useSiteMetadata()
   const [isNavOpen] = useContext(NavContext)
-  const [isMobile] = useContext(MobileContext)
   const { invertSiteLogo } = useCatalystConfig()
   const invertLogo = () => {
     if (invertSiteLogo) {
@@ -39,7 +37,7 @@ const SiteLogo = () => {
             theme => theme.sizes.logoWidthXL,
           ],
           mr: 2,
-          filter: isMobile && isNavOpen ? invertLogo : "none",
+          filter: isNavOpen ? invertLogo : "none",
           variant: "variants.siteLogo",
         }}
         fluid={logo}

--- a/themes/gatsby-theme-catalyst-header-top/src/components/branding/branding-logo.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/branding/branding-logo.js
@@ -8,12 +8,30 @@ import { useSiteMetadata } from "gatsby-theme-catalyst-core"
 import LinkWrapper from "./branding-link-wrapper"
 
 const SiteLogo = () => {
-  const { title, logo } = useSiteMetadata()
   const [isNavOpen] = useContext(NavContext)
-  const { invertSiteLogo } = useCatalystConfig()
+  const {
+    invertSiteLogo,
+    displaySiteLogo,
+    displaySiteLogoMobile,
+  } = useCatalystConfig()
+  const { title, logo } = useSiteMetadata()
   const invertLogo = () => {
     if (invertSiteLogo) {
       return "invert(1)"
+    } else {
+      return "none"
+    }
+  }
+  const displayLaptop = () => {
+    if (displaySiteLogo) {
+      return "block"
+    } else {
+      return "none"
+    }
+  }
+  const displayPhone = () => {
+    if (displaySiteLogoMobile) {
+      return "block"
     } else {
       return "none"
     }
@@ -22,6 +40,7 @@ const SiteLogo = () => {
     <LinkWrapper>
       <Img
         sx={{
+          display: [displayPhone, null, displayLaptop, null, null],
           height: [
             theme => theme.sizes.logoHeightXS,
             theme => theme.sizes.logoHeightS,

--- a/themes/gatsby-theme-catalyst-header-top/src/components/branding/branding-title.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/branding/branding-title.js
@@ -1,19 +1,42 @@
 /** @jsx jsx */
 import { jsx, Styled } from "theme-ui"
 import { useContext } from "react"
-import { useSiteMetadata } from "gatsby-theme-catalyst-core"
-import { NavContext } from "gatsby-theme-catalyst-core"
+import {
+  useSiteMetadata,
+  NavContext,
+  useCatalystConfig,
+} from "gatsby-theme-catalyst-core"
 import LinkWrapper from "./branding-link-wrapper"
 
 const SiteTitle = () => {
   const { title } = useSiteMetadata()
+  const { displaySiteTitle, displaySiteTitleMobile } = useCatalystConfig()
   const [isNavOpen] = useContext(NavContext)
+
+  const displayLaptop = () => {
+    if (displaySiteTitle) {
+      return "block"
+    } else {
+      return "none"
+    }
+  }
+  const displayPhone = () => {
+    if (displaySiteTitleMobile) {
+      return "block"
+    } else {
+      return "none"
+    }
+  }
+
+  console.log(displayLaptop())
 
   return (
     <LinkWrapper>
       <Styled.h1
         as="span"
         sx={{
+          display: [displayPhone, null, displayLaptop, null, null],
+          fontSize: [4, null, null, 5, null],
           color: isNavOpen ? "header.textOpen" : "header.text",
           textDecoration: "none",
           fontFamily: "siteTitle",

--- a/themes/gatsby-theme-catalyst-header-top/src/components/branding/branding-title.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/branding/branding-title.js
@@ -28,8 +28,6 @@ const SiteTitle = () => {
     }
   }
 
-  console.log(displayLaptop())
-
   return (
     <LinkWrapper>
       <Styled.h1

--- a/themes/gatsby-theme-catalyst-header-top/src/components/branding/branding-title.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/branding/branding-title.js
@@ -3,20 +3,18 @@ import { jsx, Styled } from "theme-ui"
 import { useContext } from "react"
 import { useSiteMetadata } from "gatsby-theme-catalyst-core"
 import { NavContext } from "gatsby-theme-catalyst-core"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import LinkWrapper from "./branding-link-wrapper"
 
 const SiteTitle = () => {
   const { title } = useSiteMetadata()
   const [isNavOpen] = useContext(NavContext)
-  const [isMobile] = useContext(MobileContext)
 
   return (
     <LinkWrapper>
       <Styled.h1
         as="span"
         sx={{
-          color: isMobile && isNavOpen ? "header.textOpen" : "header.text",
+          color: isNavOpen ? "header.textOpen" : "header.text",
           textDecoration: "none",
           fontFamily: "siteTitle",
           flex: "0 0 auto",

--- a/themes/gatsby-theme-catalyst-header-top/src/components/branding/branding.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/branding/branding.js
@@ -1,20 +1,9 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import { useContext } from "react"
-import { useCatalystConfig } from "gatsby-theme-catalyst-core"
 import Logo from "./branding-logo"
 import Title from "./branding-title"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 
 const SiteBranding = () => {
-  const {
-    displaySiteLogo,
-    displaySiteTitle,
-    displaySiteTitleMobile,
-    displaySiteLogoMobile,
-  } = useCatalystConfig()
-  const [isMobile] = useContext(MobileContext)
-
   return (
     <div
       sx={{
@@ -24,12 +13,8 @@ const SiteBranding = () => {
         mr: 2,
       }}
     >
-      {isMobile
-        ? displaySiteLogoMobile && <Logo />
-        : displaySiteLogo && <Logo />}
-      {isMobile
-        ? displaySiteTitleMobile && <Title />
-        : displaySiteTitle && <Title />}
+      <Logo />
+      <Title />
     </div>
   )
 }

--- a/themes/gatsby-theme-catalyst-header-top/src/components/header.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/header.js
@@ -4,13 +4,11 @@ import { useContext } from "react"
 import Branding from "./branding/branding"
 import Nav from "./navbar/nav"
 import MobileButton from "./navbar/nav-mobile-button"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import { NavContext } from "gatsby-theme-catalyst-core"
 import { useCatalystConfig } from "gatsby-theme-catalyst-core"
 
 const SiteHeader = () => {
   const [isNavOpen] = useContext(NavContext)
-  const [isMobile] = useContext(MobileContext)
   const { useStickyHeader } = useCatalystConfig()
   const { theme } = useThemeUI()
   return (
@@ -20,9 +18,10 @@ const SiteHeader = () => {
         position: useStickyHeader ? "sticky" : "static",
         top: 0,
         width: "100%",
-        color: isMobile && isNavOpen ? "header.textOpen" : "header.text",
-        backgroundColor:
-          isMobile && isNavOpen ? "header.backgroundOpen" : "header.background",
+        color: isNavOpen ? "header.textOpen" : "header.text",
+        backgroundColor: isNavOpen
+          ? "header.backgroundOpen"
+          : "header.background",
         gridArea: "header",
         zIndex: "888", // Ensure the header is always on top
       }}
@@ -44,8 +43,7 @@ const SiteHeader = () => {
           ],
           maxWidth: "maxPageWidth",
           width: "100%",
-          height: isMobile && isNavOpen ? "100vh" : "auto",
-          minHeight: "50px",
+          minHeight: isNavOpen ? "100vh" : "50px",
           m: "0 auto",
           px: [1, null, 3, null, null],
           py: [1, null, 2, null, null],

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-color-button.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-color-button.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx, useColorMode, useThemeUI, IconButton } from "theme-ui"
 import { useContext } from "react"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import { NavContext } from "gatsby-theme-catalyst-core"
 import { FiSun, FiMoon } from "react-icons/fi"
 import { IconContext } from "react-icons"
@@ -9,7 +8,6 @@ import { IconContext } from "react-icons"
 const ColorModeButton = () => {
   const [colorMode, setColorMode] = useColorMode()
   const [isNavOpen] = useContext(NavContext)
-  const [isMobile] = useContext(MobileContext)
   const { theme } = useThemeUI()
 
   return (
@@ -18,7 +16,7 @@ const ColorModeButton = () => {
         display: "grid",
         placeItems: "center",
         cursor: "pointer",
-        color: isMobile && isNavOpen ? "header.iconsOpen" : "header.icons",
+        color: isNavOpen ? "header.iconsOpen" : "header.icons",
         width: "auto",
         height: "auto",
         p: 0,

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-li-submenu.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-li-submenu.js
@@ -1,23 +1,21 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import { useContext } from "react"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import { NavContext } from "gatsby-theme-catalyst-core"
 
 const NavLiDropdown = ({ children }) => {
-  const [isMobile] = useContext(MobileContext)
   const [isNavOpen] = useContext(NavContext)
 
   return (
     <li
       sx={{
         display: "block",
-        mb: isMobile && isNavOpen ? 1 : 3,
+        mb: isNavOpen ? 1 : 3,
         ":hover": {
           cursor: "pointer",
         },
         a: {
-          fontSize: isMobile && isNavOpen ? 1 : 2,
+          fontSize: isNavOpen ? 1 : 2,
           "::after": {
             content: "none",
           },

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-li.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-li.js
@@ -1,25 +1,23 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import { useContext } from "react"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import { NavContext } from "gatsby-theme-catalyst-core"
 
 const NavLi = ({ children, hasSubmenu }) => {
-  const [isMobile] = useContext(MobileContext)
   const [isNavOpen] = useContext(NavContext)
 
   return (
     <li
       sx={{
-        my: isMobile ? 2 : 0,
-        mr: isMobile ? 0 : 3,
+        my: [2, null, 0, null, null],
+        mr: [0, null, 3, null, null],
         cursor: "pointer",
         fontFamily: "navLinks",
         a: {
           position: "relative",
           py: 2,
           px: 1,
-          color: isMobile && isNavOpen ? "header.textOpen" : "header.text",
+          color: isNavOpen ? "header.textOpen" : "header.text",
           textDecoration: "none",
           fontWeight: "bold",
           letterSpacing: "1px",

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links.js
@@ -35,7 +35,7 @@ const NavLinksDefault = () => {
               {link.subMenu && link.subMenu.length > 0 ? (
                 <NavUlDropdown>
                   {link.subMenu.map(subLink => (
-                    <NavLiDropdown key={link.name}>
+                    <NavLiDropdown key={subLink.name}>
                       <NavMenuLink link={subLink.link}>
                         {subLink.name}
                       </NavMenuLink>

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-mobile-button.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-mobile-button.js
@@ -2,7 +2,6 @@
 import { jsx } from "theme-ui"
 import { useContext } from "react"
 import { NavContext } from "gatsby-theme-catalyst-core"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 
 const Span = ({ open }) => (
   <span
@@ -36,7 +35,6 @@ const Span = ({ open }) => (
 
 const SiteMobileButton = () => {
   const [isNavOpen, setIsNavOpen] = useContext(NavContext)
-  const [isMobile] = useContext(MobileContext)
   return (
     <button
       aria-label="Toggle Menu"
@@ -45,9 +43,9 @@ const SiteMobileButton = () => {
         gridColumn: "2 / 3",
         gridRow: "1 / 2",
         alignSelf: "center",
-        color: isMobile && isNavOpen ? "header.textOpen" : "header.text",
+        color: isNavOpen ? "header.textOpen" : "header.text",
         cursor: "pointer",
-        display: isMobile ? "block" : "none",
+        display: ["block", null, "none", null, null],
         height: "3rem",
         position: "relative",
         width: "3rem",

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-social.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-social.js
@@ -2,14 +2,12 @@
 import { jsx } from "theme-ui"
 import { useContext } from "react"
 import { NavContext } from "gatsby-theme-catalyst-core"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import { useCatalystConfig } from "gatsby-theme-catalyst-core"
 import { SocialHeader } from "gatsby-theme-catalyst-core"
 import NavColorButton from "./nav-color-button"
 
 const SocialWrapper = () => {
   const [isNavOpen] = useContext(NavContext)
-  const [isMobile] = useContext(MobileContext)
   const { useColorMode } = useCatalystConfig()
 
   return (
@@ -17,12 +15,12 @@ const SocialWrapper = () => {
       sx={{
         display: "flex",
         alignItems: "center",
-        mr: isMobile ? "auto" : 2,
+        mr: ["auto", null, 2, null, null],
         ml: "auto",
-        mt: isMobile ? 2 : 0,
+        mt: [2, null, 0, null, null],
         a: {
-          color: isMobile && isNavOpen ? "header.iconsOpen" : "header.icons",
-          mr: isMobile && isNavOpen ? 3 : 2,
+          color: isNavOpen ? "header.iconsOpen" : "header.icons",
+          mr: isNavOpen ? 3 : 2,
           textDecoration: "none",
           display: "grid",
           placeItems: "center",

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-ul-submenu.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-ul-submenu.js
@@ -1,26 +1,25 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import { useContext } from "react"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import { NavContext } from "gatsby-theme-catalyst-core"
 
 const NavUlDropdown = ({ children }) => {
-  const [isMobile] = useContext(MobileContext)
   const [isNavOpen] = useContext(NavContext)
 
   return (
     <ul
       sx={{
-        position: isMobile && isNavOpen ? "static" : "absolute",
+        position: isNavOpen ? "static" : "absolute",
         m: 0,
         p: 0,
-        pt: isMobile && isNavOpen ? 1 : 3,
+        pt: isNavOpen ? 1 : 3,
         listStyle: "none",
-        visibility: isMobile && isNavOpen ? "visible" : "hidden",
-        display: isMobile && isNavOpen ? "block" : "none",
-        opacity: isMobile && isNavOpen ? "1" : "0",
-        backgroundColor:
-          isMobile && isNavOpen ? "header.backgroundOpen" : "header.background",
+        visibility: isNavOpen ? "visible" : "hidden",
+        display: isNavOpen ? "block" : "none",
+        opacity: isNavOpen ? "1" : "0",
+        backgroundColor: isNavOpen
+          ? "header.backgroundOpen"
+          : "header.background",
         transition: "all 0.5s ease",
         zIndex: 1,
         minWidth: "8rem",

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-ul.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-ul.js
@@ -1,18 +1,14 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import { useContext } from "react"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 
 const NavUl = ({ children }) => {
-  const [isMobile] = useContext(MobileContext)
-
   return (
     <ul
       sx={{
         display: "flex",
-        flexDirection: isMobile ? "column" : "row",
+        flexDirection: ["column", null, "row", null, null],
         flexWrap: "wrap",
-        textAlign: isMobile ? "center" : "left",
+        textAlign: ["center", null, "left", null, null],
         listStyle: "none",
         m: 0,
         p: 0,

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav.js
@@ -2,25 +2,23 @@
 import { jsx } from "theme-ui"
 import { useContext } from "react"
 import { NavContext } from "gatsby-theme-catalyst-core"
-import { MobileContext } from "gatsby-theme-catalyst-core"
 import NavLinks from "./nav-links"
 import NavSocialLinks from "./nav-social"
 
 const Nav = () => {
   const [isNavOpen] = useContext(NavContext)
-  const [isMobile] = useContext(MobileContext)
 
   return (
     <nav
       sx={{
-        gridColumn: isMobile ? "1 / -1" : "2 / 3",
-        gridRow: isMobile ? "2 / 3" : "1 / 2",
-        justifySelf: isMobile ? "center" : "end",
-        alignSelf: isMobile ? "start" : "center",
+        gridColumn: ["1 / -1", null, "2 / 3", null, null],
+        gridRow: ["2 / 3", null, "1 / 2", null, null],
+        justifySelf: ["center", null, "end", null, null],
+        alignSelf: ["start", null, "center", null, null],
         alignItems: "center",
-        mt: isMobile && isNavOpen ? 2 : 0,
-        display: isMobile ? (isNavOpen ? "flex" : "none") : "flex",
-        flexDirection: isMobile ? "column" : "row",
+        mt: isNavOpen ? 2 : 0,
+        display: [isNavOpen ? "flex" : "none", null, "flex", null, null],
+        flexDirection: ["column", null, "row", null, null],
       }}
     >
       <NavLinks />


### PR DESCRIPTION
This removes the `isMobile` context and falls back to css media queries. There was a performance problem that cannot be overcome because of SSR rendering which was causing problems with FOUC on pages.

The nav menu switches mobile now based on the second breakpoint, '768px' by default.