### PR TITLE
(hydrogen): add ability to pass down core theme options

### DIFF
--- a/themes/gatsby-theme-catalyst-hydrogen/README.md
+++ b/themes/gatsby-theme-catalyst-hydrogen/README.md
@@ -20,12 +20,71 @@ gatsby new catalyst-hydrogen https://github.com/ehowey/gatsby-starter-catalyst-h
 
 ## Theme options
 
-These theme options are used to properly access images and data from Sanity. I would recommend just setting these up in environment variables as you will need an environment variables file to store your access token anyways.
+Hydrogen accepts all options from the core theme and sanity theme directly, e.g. you can set `sanityProjectId` via `gatsby-theme-catalyst-hydrogen` and it is passed down to the correct theme appropriately. You may want to consider using environment variables for some of your SANITY.io information, if you are using a token then you _need_ to use environment variables so you do not commit this to GitHub.
 
-| Option          | Values | Description                                                                          |
-| --------------- | ------ | ------------------------------------------------------------------------------------ |
-| sanityDataset   | String | Defaults to "production", change to reflect the dataset name you are using in Sanity |
-| sanityProjectID | String | Required, Sanity project ID                                                          |
+For example the following config is valid:
+
+```js
+{
+      resolve: `gatsby-theme-catalyst-hydrogen`,
+      options: {
+        // Core theme
+        invertLogo: false,
+        footerContentLocation: "right",
+        useStickyHeader: true,
+        // Sanity theme
+        sanityProjectId: "abc123",
+        sanityDataset: "development",
+      },
+    },
+```
+
+### Core Theme Options
+
+| Option             | Values        | Description                                                                             |
+| ------------------ | ------------- | --------------------------------------------------------------------------------------- |
+| `contentPath`      | String        | Defaults to "content/pages", determines where the pages are created from.               |
+| `assetPath`        | String        | Defaults to "content/assets", determines where the page assets like images are located. |
+| `displaySiteLogo`  | true or false | Defaults to true, controls whether the logo is displayed                                |
+| `displaySiteTitle` | true or false | Defaults to true, controls whether the site title is displayed                          |
+| `invertLogo`       | true or false | Defaults to false, controls whether the logo is inverted when the mobile menu is open   |
+| `useStickyHeader`  | true or false | Defaults to false, controls whether the header is sticky or static                      |
+| `useSocialLinks`   | true or false | Defaults to true, controls whether the social links are displayed or not                |
+| `useColorMode`     | true or false | Defaults to true, controls whether the dark mode toggle is available.                   |
+
+### Sanity Theme Options
+
+| Option                   | Values  | Description                                                                                                                                |
+| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| sanityProjectId          | String  | Required, Sanity project ID                                                                                                                |
+| sanityDataset            | String  | Defaults to "production", change to reflect the dataset name you are using in Sanity                                                       |
+| sanityToken              | String  | Defaults to null, should only be used with env variables for security purposes.                                                            |
+| sanityWatchMode          | Boolean | Defaults to true, toggle for watch mode                                                                                                    |
+| sanityOverlayDrafts      | Boolean | Defaults to false, toggle for live previews, a token and private dataset is required.                                                      |
+| sanityCreatePages        | Boolean | Defaults to true, toggle to turn on/off page generation from SANITY.io.                                                                    |
+| sanityCreatePosts        | Boolean | Defaults to true, toggle to turn on/off blog post page generation from SANITY.io.                                                          |
+| sanityCreatePostsList    | Boolean | Defaults to true, toggle to turn on/off blog post list generation from SANITY.io.                                                          |
+| sanityCreateProjects     | Boolean | Defaults to true, toggle to turn on/off project page generation from SANITY.io.                                                            |
+| sanityCreateProjectsList | Boolean | Defaults to true, toggle to turn on/off project list generation from SANITY.io.                                                            |
+| sanityPostPath           | String  | Defaults to "/posts", is the path for the posts index and also before posts, e.g. site.com/posts/post-1.                                   |
+| sanityProjectPath        | String  | Defaults to "/projects", is the path for the projects index and also before projects, e.g. site.com/projects/post-1.                       |
+| useSanityTheme           | Boolean | Experimental. Enables merging the theme-ui theme specification from SANITY.io allowing use of a GUI to change the site theme, e.g. colors. |
+
+### Environment Variables
+
+You can read the [Gatsby docs about environment variables](https://www.gatsbyjs.org/docs/environment-variables/) which may be helpful.
+
+At the top of your gatsby-config.js file you will want the following, `require("dotenv").config()`
+
+Then in your site you can create a `.env` file in your main site directory with the following information. You do not want to commit this file to git as the token should remain private.
+
+Example .env:
+
+```
+SANITY_PROJECT_ID = utcr8kb1
+SANITY_DATASET = production
+SANITY_TOKEN = skRE6nh0PRCFP4juyGzMC7gvlop (actual token is much longer)
+```
 
 Example config:
 
@@ -37,18 +96,4 @@ Example config:
     sanityDataset: process.env.SANITY_DATASET,
   },
 },
-```
-
-**Environment Variable**
-
-You can read the [Gatsby docs about environment variables](https://www.gatsbyjs.org/docs/environment-variables/) which may be helpful.
-
-At the top of your gatsby-config.js file you will want the following, `require("dotenv").config()`
-
-Then in your site you can create a `.env` file in your main site directory with the following information. You do not want to commit this file to git as the token should remain private.
-
-```
-SANITY_PROJECT_ID = utcr8kb1
-SANITY_DATASET = production
-SANITY_TOKEN = skRE6nh0PRCFP4juyGzMC7gvlop (actual token is much longer)
 ```

--- a/themes/gatsby-theme-catalyst-hydrogen/gatsby-config.js
+++ b/themes/gatsby-theme-catalyst-hydrogen/gatsby-config.js
@@ -4,21 +4,17 @@ module.exports = (themeOptions) => {
       {
         resolve: `gatsby-theme-catalyst-core`,
         options: {
-          //Default options are:
-          // contentPath: `content/pages`,
-          // assetPath: `content/assets`,
-          // displaySiteLogo: true,
-          // displaySiteTitle: true,
-          // displaySiteLogoMobile: true,
-          // displaySiteTitleMobile: true,
-          // invertLogo: false,
-          // useStickyHeader: false,
-          // useSocialLinks: true,
-          // useColorMode: true,
-          //footerContentLocation: "left", // "left", "right", "center"
-          displaySiteLogo: false,
-          displaySiteLogoMobile: false,
-          useColorMode: false,
+          contentPath: themeOptions.contentPath,
+          assetPath: themeOptions.assetPath,
+          displaySiteLogo: themeOptions.displaySiteLogo || false,
+          displaySiteTitle: themeOptions.displaySiteTitle,
+          displaySiteLogoMobile: themeOptions.displaySiteLogoMobile || false,
+          displaySiteTitleMobile: themeOptions.displaySiteTitleMobile,
+          invertLogo: themeOptions.invertLogo,
+          useStickyHeader: themeOptions.useStickyHeader,
+          useSocialLinks: themeOptions.useSocialLinks,
+          useColorMode: themeOptions.useColorMode || false,
+          footerContentLocation: themeOptions.footerContentLocation, // "left", "right", "center"
         },
       },
       `gatsby-theme-catalyst-header-top`,

--- a/themes/gatsby-theme-catalyst-sanity/README.md
+++ b/themes/gatsby-theme-catalyst-sanity/README.md
@@ -15,3 +15,21 @@ Sibling theme for `gatsby-theme-catalyst-core` which adds a SANITY.io.
 ## About Gatsby Theme Catalyst
 
 The Catalyst series of themes and starters for [GatsbyJS](https://www.gatsbyjs.org/) were designed to provide an opinionated set of integrated themes and starters that can be used to accelerate your next Gatsby project. The vision is for one "core" theme in which most dependencies and components are contained followed by progressively more styled and refined child themes and starters. These themes rely heavily on [Theme-UI](https://theme-ui.com/) and [MDX](https://mdxjs.com/getting-started/gatsby/).
+
+## Theme Options
+
+| Option                   | Values  | Description                                                                                                                                |
+| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| sanityProjectId          | String  | Required, Sanity project ID                                                                                                                |
+| sanityDataset            | String  | Defaults to "production", change to reflect the dataset name you are using in Sanity                                                       |
+| sanityToken              | String  | Defaults to null, should only be used with env variables for security purposes.                                                            |
+| sanityWatchMode          | Boolean | Defaults to true, toggle for watch mode                                                                                                    |
+| sanityOverlayDrafts      | Boolean | Defaults to false, toggle for live previews, a token and private dataset is required.                                                      |
+| sanityCreatePages        | Boolean | Defaults to true, toggle to turn on/off page generation from SANITY.io.                                                                    |
+| sanityCreatePosts        | Boolean | Defaults to true, toggle to turn on/off blog post page generation from SANITY.io.                                                          |
+| sanityCreatePostsList    | Boolean | Defaults to true, toggle to turn on/off blog post list generation from SANITY.io.                                                          |
+| sanityCreateProjects     | Boolean | Defaults to true, toggle to turn on/off project page generation from SANITY.io.                                                            |
+| sanityCreateProjectsList | Boolean | Defaults to true, toggle to turn on/off project list generation from SANITY.io.                                                            |
+| sanityPostPath           | String  | Defaults to "/posts", is the path for the posts index and also before posts, e.g. site.com/posts/post-1.                                   |
+| sanityProjectPath        | String  | Defaults to "/projects", is the path for the projects index and also before projects, e.g. site.com/projects/post-1.                       |
+| useSanityTheme           | Boolean | Experimental. Enables merging the theme-ui theme specification from SANITY.io allowing use of a GUI to change the site theme, e.g. colors. |


### PR DESCRIPTION
- adds the ability to pass down core theme options directly from `gatsby-theme-catalyst-hydrogen` to `gatsby-theme-catalyst-core`