### PR TITLE
(core): ensure file folders are created for contentPath and assetPath

### DIFF
--- a/themes/gatsby-theme-catalyst-core/gatsby-config.js
+++ b/themes/gatsby-theme-catalyst-core/gatsby-config.js
@@ -1,6 +1,8 @@
 const remarkSlug = require("remark-slug")
+const withDefaults = require(`./src/utils/default-options`)
 
 module.exports = (themeOptions) => {
+  const options = withDefaults(themeOptions)
   const remarkImagesWidth =
     themeOptions.remarkImagesWidth == null
       ? 1440
@@ -32,20 +34,20 @@ module.exports = (themeOptions) => {
         resolve: `gatsby-source-filesystem`,
         options: {
           name: `pages`,
-          path: themeOptions.contentPath || `content/pages`,
+          path: options.contentPath || `content/pages`,
         },
       },
       {
         resolve: `gatsby-source-filesystem`,
         options: {
           name: `images`,
-          path: themeOptions.assetPath || `content/assets`,
+          path: options.assetPath || `content/assets`,
         },
       },
       {
         resolve: `gatsby-plugin-page-creator`,
         options: {
-          path: themeOptions.contentPath || `content/pages`,
+          path: options.contentPath || `content/pages`,
         },
       },
       {

--- a/themes/gatsby-theme-catalyst-core/gatsby-node.js
+++ b/themes/gatsby-theme-catalyst-core/gatsby-node.js
@@ -1,5 +1,29 @@
 const { createContentDigest } = require(`gatsby-core-utils`)
 const { fmImagesToRelative } = require("gatsby-remark-relative-images")
+const fs = require(`fs`)
+const path = require(`path`)
+const mkdirp = require(`mkdirp`)
+const withDefaults = require(`./src/utils/default-options`)
+const Debug = require(`debug`)
+const debug = Debug(`gatsby-theme-blog-core`)
+
+// Ensure that content directories exist at site-level
+exports.onPreBootstrap = ({ store }, themeOptions) => {
+  const { program } = store.getState()
+  const { contentPath, assetPath } = withDefaults(themeOptions)
+
+  const dirs = [
+    path.join(program.directory, contentPath),
+    path.join(program.directory, assetPath),
+  ]
+
+  dirs.forEach((dir) => {
+    debug(`Initializing ${dir} directory`)
+    if (!fs.existsSync(dir)) {
+      mkdirp.sync(dir)
+    }
+  })
+}
 
 // Setup for gatsby-remark-relative-images
 exports.onCreateNode = ({ node }) => {

--- a/themes/gatsby-theme-catalyst-core/src/utils/default-options.js
+++ b/themes/gatsby-theme-catalyst-core/src/utils/default-options.js
@@ -1,0 +1,9 @@
+module.exports = (themeOptions) => {
+  const contentPath = themeOptions.contentPath || `content/pages`
+  const assetPath = themeOptions.assetPath || `content/assets`
+
+  return {
+    contentPath,
+    assetPath,
+  }
+}


### PR DESCRIPTION
- Modifications to `gatsby-node.js` and `gatsby-config.js` to ensure that the content path and asset path are properly created if they are not there already.  Prevents edge case problems when someone installs the theme on a non-Catalyst starter.