### PR TITLE
Fix broken links in theme documentation and make formatting consistent.

### DIFF
--- a/themes/gatsby-theme-catalyst-helium/README.md
+++ b/themes/gatsby-theme-catalyst-helium/README.md
@@ -4,7 +4,7 @@ This is an MDX based personal blog theme that ties together the core theme, blog
 
 ## Documentation
 
-[https://www.gatsbycatalyst.com/](www.gatsbycatalyst.com)
+[https://www.gatsbycatalyst.com/](https://www.gatsbycatalyst.com)
 
 ## Demos
 

--- a/themes/gatsby-theme-catalyst-hydrogen/README.md
+++ b/themes/gatsby-theme-catalyst-hydrogen/README.md
@@ -4,7 +4,7 @@ This is a full-featured theme that ties together the core theme, header and foot
 
 ## Documentation
 
-[https://www.gatsbycatalyst.com/](www.gatsbycatalyst.com)
+[https://www.gatsbycatalyst.com/](https://www.gatsbycatalyst.com)
 
 ## Demos
 

--- a/themes/gatsby-theme-catalyst-lithium/README.md
+++ b/themes/gatsby-theme-catalyst-lithium/README.md
@@ -2,11 +2,15 @@
 
 This is an MDX based personal blog theme that ties together the core theme, blog theme, header and footer themes and then uses this as a basis to create a complete website. Git is used as the CMS. Styling is intentionally basic and is intended to be customized in the starter via variants and Theme-UI.
 
-**Demos:**
+## Documentation
+
+[https://www.gatsbycatalyst.com/](https://www.gatsbycatalyst.com)
+
+## Demos:
 
 - [gatsby-starter-catalyst-lithium](https://gatsby-starter-catalyst-lithium.netlify.app/)
 
-**Catalyzing Start**
+## Catalyzing Start
 
 ```sh
 # create a new Gatsby site using the catalyst writer starter site

--- a/themes/gatsby-theme-catalyst-sanity/README.md
+++ b/themes/gatsby-theme-catalyst-sanity/README.md
@@ -4,7 +4,7 @@ Sibling theme for `gatsby-theme-catalyst-core` which adds a SANITY.io as a data 
 
 ## Documentation
 
-[https://www.gatsbycatalyst.com/](www.gatsbycatalyst.com)
+[https://www.gatsbycatalyst.com/](https://www.gatsbycatalyst.com)
 
 ## Demos
 


### PR DESCRIPTION
Links inside themes to the documentation were broken, so I fixed them. Also the documentation for lithium had inconsistent formatting to the others and was missing the link to the documentation, so I added those too.