### PR TITLE
(lithium, helium): add feed plugin to gatsby-config

### DIFF
--- a/.github/workflows/test-themes.yml
+++ b/.github/workflows/test-themes.yml
@@ -77,3 +77,15 @@ jobs:
           start: yarn serve:helium
           config-file: cypress/cypress-github-actions.json
           spec: cypress/e2e/themes.test.js
+  test_lithium:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run Tests
+        uses: cypress-io/github-action@v1
+        with:
+          build: yarn build:lithium
+          start: yarn serve:lithium
+          config-file: cypress/cypress-github-actions.json
+          spec: cypress/e2e/themes.test.js

--- a/cypress/e2e/themes.test.js
+++ b/cypress/e2e/themes.test.js
@@ -7,6 +7,7 @@ describe("Smoke Test", () => {
     cy.get("footer").should("be.visible")
   })
 })
+
 describe("Navigation Menu Test", () => {
   it("Navigation Works", () => {
     cy.viewport(1440, 900)
@@ -26,23 +27,21 @@ describe("Navigation Menu Test", () => {
     })
   })
 })
+
 describe("Color Mode Toggle Test", () => {
   it("Toggle works", () => {
     cy.viewport(1440, 900)
-    cy.wait(500)
-    cy.get("header").then(($nav) => {
-      if ($nav.find('button[aria-label*="Toggle dark mode"]').length) {
-        cy.get('button[aria-label*="Toggle dark mode"]').click()
-        cy.get("body").should("have.css", "background-color", "rgb(26, 32, 44)")
-        cy.get('button[aria-label*="Toggle dark mode"]').click()
-        cy.get("body").should(
-          "have.css",
-          "background-color",
-          "rgb(247, 250, 252)"
-        )
-      } else {
-        return "No color mode toggle"
-      }
-    })
+    cy.scrollTo("top")
+    cy.wait(1000)
+    if ('button[aria-label*="Toggle dark mode"]'.length) {
+      cy.get('button[aria-label*="Toggle dark mode"]').click()
+      cy.get("body").should("have.css", "background-color", "rgb(26, 32, 44)")
+      cy.get('button[aria-label*="Toggle dark mode"]').click()
+      cy.get("body").should(
+        "have.css",
+        "background-color",
+        "rgb(247, 250, 252)"
+      )
+    }
   })
 })

--- a/cypress/e2e/themes.test.js
+++ b/cypress/e2e/themes.test.js
@@ -33,15 +33,19 @@ describe("Color Mode Toggle Test", () => {
     cy.viewport(1440, 900)
     cy.scrollTo("top")
     cy.wait(1000)
-    if ('button[aria-label*="Toggle dark mode"]'.length) {
-      cy.get('button[aria-label*="Toggle dark mode"]').click()
-      cy.get("body").should("have.css", "background-color", "rgb(26, 32, 44)")
-      cy.get('button[aria-label*="Toggle dark mode"]').click()
-      cy.get("body").should(
-        "have.css",
-        "background-color",
-        "rgb(247, 250, 252)"
-      )
-    }
+    cy.get("header").then(($nav) => {
+      if ($nav.find('button[aria-label*="Toggle dark mode"]').length) {
+        cy.get('button[aria-label*="Toggle dark mode"]').click()
+        cy.get("body").should("have.css", "background-color", "rgb(26, 32, 44)")
+        cy.get('button[aria-label*="Toggle dark mode"]').click()
+        cy.get("body").should(
+          "have.css",
+          "background-color",
+          "rgb(247, 250, 252)"
+        )
+      } else {
+        return "No color mode toggle"
+      }
+    })
   })
 })

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test:sanity": "start-server-and-test develop:sanity http://localhost:8000 cy:open",
     "test:hydrogen": "start-server-and-test develop:hydrogen http://localhost:8000 cy:open",
     "test:helium": "start-server-and-test develop:helium http://localhost:8000 cy:open",
-    "test:lithium": "yarn workspace gatsby-starter-catalyst-lithium develop",
+    "test:lithium": "start-server-and-test develop:lithium http://localhost:8000 cy:open",
     "test:www": "start-server-and-test develop:www http://localhost:8000 cy:open",
     "cy:open": "cypress open",
     "cy:run": "cypress run"

--- a/starters/gatsby-starter-catalyst-sanity/gatsby-config.js
+++ b/starters/gatsby-starter-catalyst-sanity/gatsby-config.js
@@ -47,7 +47,6 @@ module.exports = {
         // useColorMode: true, // Dark mode is not supported when configuring the theme from SANITY.io dashboard
         // footerContentLocation: "left", // "left", "right", "center"
         // remarkImagesWidth: 1440,
-        useColorMode: false, // Dark mode is not supported by SANITY when configuring the theme spec from SANITY.io
       },
     },
     `gatsby-theme-catalyst-header-top`, // Try `gatsby-theme-catalyst-header-side`

--- a/themes/gatsby-theme-catalyst-helium/gatsby-config.js
+++ b/themes/gatsby-theme-catalyst-helium/gatsby-config.js
@@ -32,6 +32,82 @@ module.exports = (themeOptions) => {
           rssTitle: themeOptions.rssTitle,
         },
       },
+      {
+        resolve: `gatsby-plugin-feed`,
+        options: {
+          query: `
+            {
+              site {
+                siteMetadata {
+                  title
+                  description
+                  siteUrl
+                  site_url: siteUrl
+                }
+              }
+            }
+          `,
+          feeds: [
+            {
+              output: `/rss.xml`,
+              title: themeOptions.rssTitle || `RSS Feed`,
+              query: `
+                {
+                  allCatalystPost(
+                    sort: { fields: [date, title], order: DESC }
+                    limit: 1000
+                    filter: { draft: { eq: false } }
+                  ) {
+                    nodes {
+                      id
+                      slug
+                      title
+                      author
+                      excerpt
+                      date(formatString: "ddd, DD MMM YYYY HH:mm:ss ZZ")
+                      socialImage {
+                        publicURL
+                      }
+                      featuredImage {
+                        publicURL
+                      }
+                    }
+                  }
+                }
+              `,
+              serialize: ({
+                query: {
+                  site: {
+                    siteMetadata: { siteUrl },
+                  },
+                  allCatalystPost,
+                },
+              }) => {
+                const rssFeed = allCatalystPost.nodes.map((node) => {
+                  const hasSocial = node.socialImage !== null
+                  const hasFeatured = node.featuredImage !== null
+                  const rssImage = hasSocial
+                    ? `${siteUrl}${node.socialImage.publicURL}`
+                    : hasFeatured
+                    ? `${siteUrl}${node.featuredImage.publicURL}`
+                    : null
+                  const serialized = {
+                    guid: `${siteUrl}${node.slug}`,
+                    url: `${siteUrl}${node.slug}`,
+                    title: node.title,
+                    author: node.author,
+                    description: node.excerpt,
+                    pubDate: node.date,
+                    enclosure: { url: rssImage },
+                  }
+                  return serialized
+                })
+                return rssFeed
+              },
+            },
+          ],
+        },
+      },
     ].filter(Boolean),
   }
 }

--- a/themes/gatsby-theme-catalyst-lithium/gatsby-config.js
+++ b/themes/gatsby-theme-catalyst-lithium/gatsby-config.js
@@ -32,6 +32,82 @@ module.exports = (themeOptions) => {
           rssTitle: themeOptions.rssTitle,
         },
       },
+      {
+        resolve: `gatsby-plugin-feed`,
+        options: {
+          query: `
+            {
+              site {
+                siteMetadata {
+                  title
+                  description
+                  siteUrl
+                  site_url: siteUrl
+                }
+              }
+            }
+          `,
+          feeds: [
+            {
+              output: `/rss.xml`,
+              title: themeOptions.rssTitle || `RSS Feed`,
+              query: `
+                {
+                  allCatalystPost(
+                    sort: { fields: [date, title], order: DESC }
+                    limit: 1000
+                    filter: { draft: { eq: false } }
+                  ) {
+                    nodes {
+                      id
+                      slug
+                      title
+                      author
+                      excerpt
+                      date(formatString: "ddd, DD MMM YYYY HH:mm:ss ZZ")
+                      socialImage {
+                        publicURL
+                      }
+                      featuredImage {
+                        publicURL
+                      }
+                    }
+                  }
+                }
+              `,
+              serialize: ({
+                query: {
+                  site: {
+                    siteMetadata: { siteUrl },
+                  },
+                  allCatalystPost,
+                },
+              }) => {
+                const rssFeed = allCatalystPost.nodes.map((node) => {
+                  const hasSocial = node.socialImage !== null
+                  const hasFeatured = node.featuredImage !== null
+                  const rssImage = hasSocial
+                    ? `${siteUrl}${node.socialImage.publicURL}`
+                    : hasFeatured
+                    ? `${siteUrl}${node.featuredImage.publicURL}`
+                    : null
+                  const serialized = {
+                    guid: `${siteUrl}${node.slug}`,
+                    url: `${siteUrl}${node.slug}`,
+                    title: node.title,
+                    author: node.author,
+                    description: node.excerpt,
+                    pubDate: node.date,
+                    enclosure: { url: rssImage },
+                  }
+                  return serialized
+                })
+                return rssFeed
+              },
+            },
+          ],
+        },
+      },
     ].filter(Boolean),
   }
 }


### PR DESCRIPTION
- moves `gatsby-plugin-feed` up to the `lithium` and `helium` themes
- addresses #727 temporarily, not the most elegant solution but it works
- improved tests so it doesn't occasionally fail
- added test for lithium