### PR TITLE
Fix the link of the repo in catalyst-lithium README file

### DIFF
--- a/starters/gatsby-starter-catalyst-lithium/README.md
+++ b/starters/gatsby-starter-catalyst-lithium/README.md
@@ -6,7 +6,7 @@ This is a starter provides a blog that ties together the core theme, blog theme,
 
 ```sh
 # create a new Gatsby site using the catalyst writer starter site
-gatsby new catalyst-lithium https://github.com/ehowey/gatsby-starter-catalyst-lithum
+gatsby new catalyst-lithium https://github.com/ehowey/gatsby-starter-catalyst-lithium
 ```
 
 [Read the Gatsby Quick Start Guide](https://www.gatsbyjs.org/docs/quick-start)


### PR DESCRIPTION
There was an error in command that create sample gatsby-starter-catalyst-lithium project. Added one character