### PR TITLE
(header-top): add support for split links with fallback for default

### DIFF
--- a/starters/gatsby-starter-catalyst-bery/sanity-studio/schemas/menuLink.js
+++ b/starters/gatsby-starter-catalyst-bery/sanity-studio/schemas/menuLink.js
@@ -23,6 +23,20 @@ export default {
         }),
     },
     {
+      title: "Link location",
+      name: "location",
+      type: "string",
+      description:
+        "Does not apply to this theme, used in other themes and cannot be removed.",
+      options: {
+        list: [
+          { title: "Left", value: "left" },
+          { title: "Right", value: "right" },
+        ], // <-- predefined values
+        layout: "radio", // <-- defaults to 'dropdown'
+      },
+    },
+    {
       title: "Link type",
       name: "type",
       type: "string",

--- a/starters/gatsby-starter-catalyst-hydrogen/sanity-studio/schemas/menuLink.js
+++ b/starters/gatsby-starter-catalyst-hydrogen/sanity-studio/schemas/menuLink.js
@@ -23,6 +23,21 @@ export default {
         }),
     },
     {
+      title: "Link location",
+      name: "location",
+      type: "string",
+      description:
+        "Affects the visual location of the links for the top menu bar only. Allows for a 'split' link design. Does not affect some themes.",
+      options: {
+        list: [
+          { title: "Left", value: "left" },
+          { title: "Right", value: "right" },
+        ], // <-- predefined values
+        layout: "radio", // <-- defaults to 'dropdown'
+      },
+      validation: (Rule) => Rule.required(),
+    },
+    {
       title: "Link type",
       name: "type",
       type: "string",

--- a/starters/gatsby-starter-catalyst-sanity/sanity-studio/schemas/menuLink.js
+++ b/starters/gatsby-starter-catalyst-sanity/sanity-studio/schemas/menuLink.js
@@ -23,6 +23,21 @@ export default {
         }),
     },
     {
+      title: "Link location",
+      name: "location",
+      type: "string",
+      description:
+        "Affects the visual location of the links for the top menu bar only. Allows for a 'split' link design.",
+      options: {
+        list: [
+          { title: "Left", value: "left" },
+          { title: "Right", value: "right" },
+        ], // <-- predefined values
+        layout: "radio", // <-- defaults to 'dropdown'
+      },
+      validation: (Rule) => Rule.required(),
+    },
+    {
       title: "Link type",
       name: "type",
       type: "string",

--- a/starters/gatsby-starter-catalyst-sanity/sanity-studio/schemas/menuLink.js
+++ b/starters/gatsby-starter-catalyst-sanity/sanity-studio/schemas/menuLink.js
@@ -27,7 +27,7 @@ export default {
       name: "location",
       type: "string",
       description:
-        "Affects the visual location of the links for the top menu bar only. Allows for a 'split' link design.",
+        "Affects the visual location of the links for the top menu bar only. Allows for a 'split' link design. Does not affect some themes.",
       options: {
         list: [
           { title: "Left", value: "left" },

--- a/starters/gatsby-starter-catalyst/gatsby-config.js
+++ b/starters/gatsby-starter-catalyst/gatsby-config.js
@@ -16,16 +16,19 @@ module.exports = {
         name: `Page 1`,
         link: `/page-1`,
         type: `internal`, //internal or anchor
+        location: `right`,
       },
       {
         name: `Anchor 1`,
         link: `#anchor-1`,
         type: `anchor`, //internal or anchor
+        location: `right`,
       },
       {
         name: `Page 2`,
         link: `/page-2`,
         type: `internal`, //internal or anchor
+        location: `right`,
         subMenu: [
           {
             name: `Sub 1`,

--- a/starters/gatsby-starter-catalyst/gatsby-config.js
+++ b/starters/gatsby-starter-catalyst/gatsby-config.js
@@ -7,6 +7,12 @@ module.exports = {
     siteUrl: `https://gatsby-starter-catalyst.netlify.app`, //Change to you site address, required for sitemap.xml and robots.txt file among other things
     menuLinks: [
       {
+        name: `Left Link`,
+        link: `/page-1`,
+        type: `internal`, //internal or anchor
+        location: `left`,
+      },
+      {
         name: `Page 1`,
         link: `/page-1`,
         type: `internal`, //internal or anchor

--- a/themes/gatsby-theme-catalyst-core/gatsby-node.js
+++ b/themes/gatsby-theme-catalyst-core/gatsby-node.js
@@ -42,7 +42,21 @@ exports.createSchemaCustomization = ({ actions }) => {
       }
     },
   })
-  
+
+  createFieldExtension({
+    name: `defaultRightLocation`,
+    extend() {
+      return {
+        resolve(source, args, context, info) {
+          if (source[info.fieldName] == null) {
+            return "right"
+          }
+          return source[info.fieldName]
+        },
+      }
+    },
+  })
+
   // Type defination for the submenu to ensure there is always a submenu array to query
   const subMenuTypeDefs = `
     type Site implements Node @infer {
@@ -55,6 +69,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       name: String!
       link: String!
       type: String!
+      location: String! @defaultRightLocation
       subMenu: [SubMenu] @defaultSubMenu
     }
     type SubMenu {

--- a/themes/gatsby-theme-catalyst-core/src/utils/use-site-metadata.js
+++ b/themes/gatsby-theme-catalyst-core/src/utils/use-site-metadata.js
@@ -30,6 +30,7 @@ export const useSiteMetadata = () => {
               name
               link
               type
+              location
               subMenu {
                 link
                 name
@@ -51,8 +52,8 @@ export const useSiteMetadata = () => {
   const seoImage = data.seoImage.childImageSharp.resize
   const metaData = data.site.siteMetadata
   const twitterLink = data.site.siteMetadata.socialLinks
-    .filter(social => social.name.toLowerCase() === "twitter")
-    .map(social => {
+    .filter((social) => social.name.toLowerCase() === "twitter")
+    .map((social) => {
       return social.link
     })
   const twitterUsername = twitterLink.length

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-icons.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-icons.js
@@ -18,7 +18,7 @@ const SocialWrapper = () => {
         display: "flex",
         alignItems: "center",
         mr: ["auto", null, 2, null, null],
-        ml: "auto",
+        ml: ["auto", null, 2, null, null],
         mt: [2, null, 0, null, null],
         a: {
           color: isNavOpen ? "header.iconsOpen" : "header.icons",

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-left.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-left.js
@@ -14,10 +14,17 @@ import { HomeContext } from "gatsby-theme-catalyst-core"
 
 const NavLinksDefault = () => {
   const { menuLinks } = useSiteMetadata()
+  const leftLinks = menuLinks.filter((link) => link.location === "left")
   const [isHome] = useContext(HomeContext)
   return (
-    <NavUL>
-      {menuLinks.map((link) => {
+    <div
+      sx={{
+        display: "flex",
+        flexDirection: ["column", null, "row", null, null],
+        flexWrap: "wrap",
+      }}
+    >
+      {leftLinks.map((link) => {
         const hasSubmenu = link.subMenu && link.subMenu.length > 0
         return (
           <NavLI key={link.name} hasSubmenu={hasSubmenu ? true : false}>
@@ -54,7 +61,7 @@ const NavLinksDefault = () => {
           </NavLI>
         )
       })}
-    </NavUL>
+    </div>
   )
 }
 

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-left.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-left.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import { Fragment, useContext } from "react"
-import NavUL from "./nav-ul"
 import NavLI from "./nav-li"
 import NavUlDropdown from "./nav-ul-submenu"
 import NavLiDropdown from "./nav-li-submenu"

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-right.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-right.js
@@ -13,7 +13,7 @@ import { HomeContext } from "gatsby-theme-catalyst-core"
 
 const NavLinksDefault = () => {
   const { menuLinks } = useSiteMetadata()
-  const rightLinks = menuLinks.filter((link) => link.location === "right")
+  const rightLinks = menuLinks.filter((link) => link.location !== "left")
   console.log(rightLinks)
   const [isHome] = useContext(HomeContext)
   return (

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-right.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-right.js
@@ -1,0 +1,70 @@
+/** @jsx jsx */
+import { jsx } from "theme-ui"
+import { Fragment, useContext } from "react"
+import NavUL from "./nav-ul"
+import NavLI from "./nav-li"
+import NavUlDropdown from "./nav-ul-submenu"
+import NavLiDropdown from "./nav-li-submenu"
+import NavMenuLink from "./nav-links-gatsbylink"
+import NavMenuAnchorLink from "./nav-links-anchorlink"
+import { useSiteMetadata } from "gatsby-theme-catalyst-core"
+import { HomeContext } from "gatsby-theme-catalyst-core"
+
+// This component has a lot going on. It is handling the mapping of the menu items, optionally using anchor links, and optionally showing a dropdown menu. It is broken into smaller components for readability here but could be condensed into one mega component if you wanted.
+
+const NavLinksDefault = () => {
+  const { menuLinks } = useSiteMetadata()
+  const rightLinks = menuLinks.filter((link) => link.location === "right")
+  console.log(rightLinks)
+  const [isHome] = useContext(HomeContext)
+  return (
+    <div
+      sx={{
+        display: "flex",
+        flexDirection: ["column", null, "row", null, null],
+        flexWrap: "wrap",
+        textAlign: ["center", null, "left", null, null],
+      }}
+    >
+      {rightLinks.map((link) => {
+        const hasSubmenu = link.subMenu && link.subMenu.length > 0
+        return (
+          <NavLI key={link.name} hasSubmenu={hasSubmenu ? true : false}>
+            {link.type === "internal" && (
+              <Fragment>
+                <NavMenuLink
+                  link={link.link}
+                  hasSubmenu={hasSubmenu ? true : false}
+                >
+                  {link.name}
+                </NavMenuLink>
+                {hasSubmenu ? (
+                  <NavUlDropdown>
+                    {link.subMenu.map((subLink) => (
+                      <NavLiDropdown key={subLink.name}>
+                        <NavMenuLink link={subLink.link}>
+                          {subLink.name}
+                        </NavMenuLink>
+                      </NavLiDropdown>
+                    ))}
+                  </NavUlDropdown>
+                ) : null}
+              </Fragment>
+            )}
+            {isHome && link.type === "anchor" ? (
+              <NavMenuAnchorLink link={link.link}>
+                {link.name}
+              </NavMenuAnchorLink>
+            ) : (
+              link.type === "anchor" && (
+                <NavMenuLink link={"/" + link.link}>{link.name}</NavMenuLink>
+              )
+            )}
+          </NavLI>
+        )
+      })}
+    </div>
+  )
+}
+
+export default NavLinksDefault

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-right.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-right.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import { Fragment, useContext } from "react"
-import NavUL from "./nav-ul"
 import NavLI from "./nav-li"
 import NavUlDropdown from "./nav-ul-submenu"
 import NavLiDropdown from "./nav-li-submenu"

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-ul.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-ul.js
@@ -5,8 +5,10 @@ const NavUl = ({ children }) => {
   return (
     <ul
       sx={{
+        width: "100%",
         display: "flex",
         flexDirection: ["column", null, "row", null, null],
+        justifyContent: [null, null, "space-between", null, null],
         flexWrap: "wrap",
         textAlign: ["center", null, "left", null, null],
         listStyle: "none",

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav.js
@@ -2,7 +2,9 @@
 import { jsx } from "theme-ui"
 import { useContext } from "react"
 import { NavContext } from "gatsby-theme-catalyst-core"
-import NavLinks from "./nav-links"
+import NavUL from "./nav-ul"
+import NavLinksLeft from "./nav-links-left"
+import NavLinksRight from "./nav-links-right"
 import NavIcons from "./nav-icons"
 
 const Nav = () => {
@@ -11,6 +13,7 @@ const Nav = () => {
   return (
     <nav
       sx={{
+        width: "100%",
         gridColumn: ["1 / -1", null, "2 / 3", null, null],
         gridRow: ["2 / 3", null, "1 / 2", null, null],
         justifySelf: ["center", null, "end", null, null],
@@ -19,11 +22,15 @@ const Nav = () => {
         mt: isNavOpen ? 2 : 0,
         display: [isNavOpen ? "flex" : "none", null, "flex", null, null],
         flexDirection: ["column", null, "row", null, null],
+        justifyContent: "flex-end",
         variant: "variant.nav",
       }}
       aria-label="Primary menu"
     >
-      <NavLinks />
+      <NavUL>
+        <NavLinksLeft />
+        <NavLinksRight />
+      </NavUL>
       <NavIcons />
     </nav>
   )

--- a/themes/gatsby-theme-catalyst-sanity/src/gatsby-theme-catalyst-core/utils/use-site-metadata.js
+++ b/themes/gatsby-theme-catalyst-sanity/src/gatsby-theme-catalyst-core/utils/use-site-metadata.js
@@ -38,6 +38,7 @@ export const useSiteMetadata = () => {
             link
             name
             type
+            location
             subMenu {
               link
               name


### PR DESCRIPTION
- adds support to `gatsby-theme-catalyst-header-top` for split links, e.g. links on the left and links on the right. The default is for the links to be stacked on the right. And will not affect any current behaviour.  If you are doing a lot of custom component shadowing on top of this theme you may need to revisit how you are component shadowing but that is an advanced use case.
- **BREAKING CHANGE**: This is a breaking change ONLY for SANITY.io based themes and will require you to update your `menuLinks.js` schema and redeploy the GraphQL schema,  I am sorry but there isn't a way in SANITY for me to easily control the GraphQL node creation and this will require an update.
- You can now specify a `location: "left"` or `location: "right"` in the menuLinks array in `gatsby-config.js`
- This is not required and will continue to work unaffected if you leave everything alone in MDX themes