### PR TITLE
(header-top): switch div and ul tag order for correct semantic structure in links

### DIFF
--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-left.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-left.js
@@ -17,8 +17,11 @@ const NavLinksLeft = () => {
   const [activeDropdown, setActiveDropdown] = useState(null)
   const [isHome] = useContext(HomeContext)
   return (
-    <div
+    <ul
       sx={{
+        listStyle: "none",
+        m: 0,
+        p: 0,
         display: "flex",
         flexDirection: ["column", null, "row", null, null],
         alignItems: "center",
@@ -79,7 +82,7 @@ const NavLinksLeft = () => {
           </NavLI>
         )
       })}
-    </div>
+    </ul>
   )
 }
 

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-right.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-links-right.js
@@ -17,8 +17,11 @@ const NavLinksRight = () => {
   const [activeDropdown, setActiveDropdown] = useState(null)
   const [isHome] = useContext(HomeContext)
   return (
-    <div
+    <ul
       sx={{
+        listStyle: "none",
+        m: 0,
+        p: 0,
         display: "flex",
         flexDirection: ["column", null, "row", null, null],
         alignItems: "center",
@@ -79,7 +82,7 @@ const NavLinksRight = () => {
           </NavLI>
         )
       })}
-    </div>
+    </ul>
   )
 }
 

--- a/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-ul.js
+++ b/themes/gatsby-theme-catalyst-header-top/src/components/navbar/nav-ul.js
@@ -3,7 +3,7 @@ import { jsx } from "theme-ui"
 
 const NavUl = ({ children }) => {
   return (
-    <ul
+    <div
       sx={{
         width: "100%",
         display: "flex",
@@ -11,14 +11,11 @@ const NavUl = ({ children }) => {
         justifyContent: [null, null, "space-between", null, null],
         flexWrap: "wrap",
         textAlign: ["center", null, "left", null, null],
-        listStyle: "none",
-        m: 0,
-        p: 0,
         variant: "variants.navUl",
       }}
     >
       {children}
-    </ul>
+    </div>
   )
 }
 


### PR DESCRIPTION
In order to support both a left and right nav menu the structure included a splitter div in the middle separating the two lists. This should have been a ul element.