### PR TITLE
(core): add imageQuality theme option

### DIFF
--- a/themes/gatsby-theme-catalyst-core/gatsby-config.js
+++ b/themes/gatsby-theme-catalyst-core/gatsby-config.js
@@ -9,6 +9,8 @@ module.exports = (themeOptions) => {
     themeOptions.remarkImagesWidth == null
       ? 1440
       : parseInt(themeOptions.remarkImagesWidth)
+  const imageQuality =
+    themeOptions.imageQuality == null ? 50 : parseInt(themeOptions.imageQuality)
   const gatsbyRemarkPlugins = [
     {
       resolve: `gatsby-remark-relative-images`,
@@ -21,6 +23,7 @@ module.exports = (themeOptions) => {
         linkImagesToOriginal: false,
         withWebp: true,
         backgroundColor: `transparent`,
+        quality: imageQuality,
       },
     },
     {
@@ -106,6 +109,7 @@ module.exports = (themeOptions) => {
                 linkImagesToOriginal: false,
                 withWebp: true,
                 backgroundColor: `transparent`,
+                quality: imageQuality,
               },
             },
           ],
@@ -118,7 +122,12 @@ module.exports = (themeOptions) => {
       `gatsby-transformer-sharp`,
       `gatsby-transformer-yaml`,
       `gatsby-transformer-json`,
-      `gatsby-plugin-sharp`,
+      {
+        resolve: `gatsby-plugin-sharp`,
+        options: {
+          quality: imageQuality,
+        },
+      },
       `gatsby-plugin-catch-links`,
       `gatsby-plugin-theme-ui`,
     ].filter(Boolean),


### PR DESCRIPTION
As identified by @wgx it is not easy to currently change the default image compression settings. This PR would introduce an `imageQuality` theme option that could be set on the core theme and would affect all images generated by `gatsby-plugin-sharp` and `gatsby-remark-images`.  

@wgx Is this what you are looking for?

Fixes: https://github.com/ehowey/gatsby-theme-catalyst/issues/1127