### PR TITLE
(sanity): remove values from graphql nodes

### DIFF
--- a/starters/gatsby-starter-catalyst-sanity/gatsby-config.js
+++ b/starters/gatsby-starter-catalyst-sanity/gatsby-config.js
@@ -73,6 +73,10 @@ module.exports = {
         // sanityCreateProjectsList: true
         // sanityPostPath: "/posts"
         // sanityProjectPath: "/projects"
+        // sanityPostListTitle: "Posts"
+        // sanityDisplayPostListTitle: true
+        // sanityProjectListTitle: "Projects"
+        // sanityDisplayProjectListTitle: true
         // useSanityTheme: false // Experimental right now
         sanityProjectId: "p9a6h8j1",
       },

--- a/themes/gatsby-theme-catalyst-core/gatsby-node.js
+++ b/themes/gatsby-theme-catalyst-core/gatsby-node.js
@@ -94,7 +94,6 @@ exports.createSchemaCustomization = ({ actions }) => {
     displaySiteLogoMobile: Boolean!
     displaySiteTitleMobile: Boolean!
     invertSiteLogo: Boolean!
-    mobileMenuBreakpoint: String!
     useStickyHeader: Boolean!
     useSocialLinks: Boolean!
     useColorMode: Boolean!
@@ -116,7 +115,6 @@ exports.sourceNodes = (
     displaySiteLogoMobile = true,
     displaySiteTitleMobile = true,
     invertSiteLogo = false,
-    mobileMenuBreakpoint = "768px",
     useStickyHeader = false,
     useSocialLinks = true,
     useColorMode = true,
@@ -133,7 +131,6 @@ exports.sourceNodes = (
     displaySiteLogoMobile,
     displaySiteTitleMobile,
     invertSiteLogo,
-    mobileMenuBreakpoint,
     useStickyHeader,
     useSocialLinks,
     useColorMode,

--- a/themes/gatsby-theme-catalyst-core/src/utils/use-catalyst-config.js
+++ b/themes/gatsby-theme-catalyst-core/src/utils/use-catalyst-config.js
@@ -11,7 +11,6 @@ export const useCatalystConfig = () => {
           displaySiteLogoMobile
           displaySiteTitleMobile
           invertSiteLogo
-          mobileMenuBreakpoint
           useStickyHeader
           useSocialLinks
           useColorMode

--- a/themes/gatsby-theme-catalyst-sanity/README.md
+++ b/themes/gatsby-theme-catalyst-sanity/README.md
@@ -12,24 +12,28 @@ This theme adds a data layer for SANITY.io on top of `gatsby-theme-catalyst-core
 
 ## Theme Options
 
-| Option                   | Values  | Description                                                                                                                                |
-| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| sanityProjectId          | String  | Required, Sanity project ID                                                                                                                |
-| sanityDataset            | String  | Defaults to "production", change to reflect the dataset name you are using in Sanity                                                       |
-| sanityToken              | String  | Defaults to null, should only be used with env variables for security purposes.                                                            |
-| sanityWatchMode          | Boolean | Defaults to true, toggle for watch mode                                                                                                    |
-| sanityOverlayDrafts      | Boolean | Defaults to false, toggle for live previews, a token and private dataset is required.                                                      |
-| sanityCreatePages        | Boolean | Defaults to true, toggle to turn on/off page generation from SANITY.io.                                                                    |
-| sanityCreatePosts        | Boolean | Defaults to true, toggle to turn on/off blog post page generation from SANITY.io.                                                          |
-| sanityCreateCategories   | Boolean | Defaults to true, toggle to turn on/off category page generation from SANITY.io.                                                           |
-| sanityCreatePostsList    | Boolean | Defaults to true, toggle to turn on/off blog post list generation from SANITY.io.                                                          |
-| sanityCreateProjects     | Boolean | Defaults to true, toggle to turn on/off project page generation from SANITY.io.                                                            |
-| sanityCreateProjectsList | Boolean | Defaults to true, toggle to turn on/off project list generation from SANITY.io.                                                            |
-| sanityPostPath           | String  | Defaults to "/posts", is the path for before posts, e.g. site.com/posts/post-1.                                                            |
-| sanityPostListPath       | String  | Defaults to "/posts", is the path for the posts list, e.g. site.com/posts/.                                                                |
-| sanityProjectPath        | String  | Defaults to "/projects", is the path for before projects, e.g. site.com/projects/post-1.                                                   |
-| sanityProjectListPath    | String  | Defaults to "/projects", is the path for the projects list page, e.g. site.com/projects/.                                                  |
-| useSanityTheme           | Boolean | Experimental. Enables merging the theme-ui theme specification from SANITY.io allowing use of a GUI to change the site theme, e.g. colors. |
+| Option                        | Values  | Description                                                                                                                                |
+| ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| sanityProjectId               | String  | Required, Sanity project ID                                                                                                                |
+| sanityDataset                 | String  | Defaults to "production", change to reflect the dataset name you are using in Sanity                                                       |
+| sanityToken                   | String  | Defaults to null, should only be used with env variables for security purposes.                                                            |
+| sanityWatchMode               | Boolean | Defaults to true, toggle for watch mode                                                                                                    |
+| sanityOverlayDrafts           | Boolean | Defaults to false, toggle for live previews, a token and private dataset is required.                                                      |
+| sanityCreatePages             | Boolean | Defaults to true, toggle to turn on/off page generation from SANITY.io.                                                                    |
+| sanityCreatePosts             | Boolean | Defaults to true, toggle to turn on/off blog post page generation from SANITY.io.                                                          |
+| sanityCreateCategories        | Boolean | Defaults to true, toggle to turn on/off category page generation from SANITY.io.                                                           |
+| sanityCreatePostsList         | Boolean | Defaults to true, toggle to turn on/off blog post list generation from SANITY.io.                                                          |
+| sanityCreateProjects          | Boolean | Defaults to true, toggle to turn on/off project page generation from SANITY.io.                                                            |
+| sanityCreateProjectsList      | Boolean | Defaults to true, toggle to turn on/off project list generation from SANITY.io.                                                            |
+| sanityPostPath                | String  | Defaults to "/posts", is the path for before posts, e.g. site.com/posts/post-1.                                                            |
+| sanityPostListPath            | String  | Defaults to "/posts", is the path for the posts list, e.g. site.com/posts/.                                                                |
+| sanityProjectPath             | String  | Defaults to "/projects", is the path for before projects, e.g. site.com/projects/post-1.                                                   |
+| sanityProjectListPath         | String  | Defaults to "/projects", is the path for the projects list page, e.g. site.com/projects/.                                                  |
+| sanityPostListTitle           | String  | Defaults to "Posts", is title for the posts list page.                                                                                     |
+| sanityProjectListTitle        | String  | Defaults to "Projects", is title for the projects list page.                                                                               |
+| sanityDisplayPostListTitle    | Boolean | Defaults to true, toggle to turn on/off the post list title.io.                                                                            |
+| sanityDisplayProjectListTitle | Boolean | Defaults to true, toggle to turn on/off the project list title.io.                                                                         |
+| useSanityTheme                | Boolean | Experimental. Enables merging the theme-ui theme specification from SANITY.io allowing use of a GUI to change the site theme, e.g. colors. |
 
 ## Sanity Studio
 

--- a/themes/gatsby-theme-catalyst-sanity/gatsby-node.js
+++ b/themes/gatsby-theme-catalyst-sanity/gatsby-node.js
@@ -375,11 +375,6 @@ exports.createPages = async ({ graphql, actions, reporter }, themeOptions) => {
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions
   createTypes(`type CatalystSanityConfig implements Node {
-    sanityProjectId: String!
-    sanityDataset: String!
-    sanityToken: String
-    sanityWatchMode: Boolean!
-    sanityOverlayDrafts: Boolean!
     sanityCreatePages: Boolean!
     sanityCreatePosts: Boolean!
     sanityCreatePostsList: Boolean!
@@ -401,11 +396,6 @@ exports.createSchemaCustomization = ({ actions }) => {
 exports.sourceNodes = (
   { actions: { createNode }, schema },
   {
-    sanityProjectId = "abc123",
-    sanityDataset = "production",
-    sanityToken = null,
-    sanityWatchMode = true,
-    sanityOverlayDrafts = false,
     sanityCreatePages = true,
     sanityCreatePosts = true,
     sanityCreatePostsList = true,
@@ -425,11 +415,6 @@ exports.sourceNodes = (
 ) => {
   // create garden data from plugin config
   const catalystSanityConfigFieldData = {
-    sanityProjectId,
-    sanityDataset,
-    sanityToken,
-    sanityWatchMode,
-    sanityOverlayDrafts,
     sanityCreatePages,
     sanityCreatePosts,
     sanityCreatePostsList,

--- a/themes/gatsby-theme-catalyst-sanity/src/components/sanity/use-sanity-config.js
+++ b/themes/gatsby-theme-catalyst-sanity/src/components/sanity/use-sanity-config.js
@@ -4,9 +4,6 @@ export const useSanityConfig = () => {
     graphql`
       query {
         catalystSanityConfig {
-          sanityDataset
-          sanityProjectId
-          sanityToken
           sanityCreatePages
           sanityCreatePosts
           sanityCreatePostsList
@@ -20,6 +17,8 @@ export const useSanityConfig = () => {
           useSanityTheme
           sanityPostListTitle
           sanityDisplayPostListTitle
+          sanityProjectListTitle
+          sanityDisplayProjectListTitle
         }
       }
     `

--- a/www/content/docs/docs/gatsby-theme-catalyst-sanity.mdx
+++ b/www/content/docs/docs/gatsby-theme-catalyst-sanity.mdx
@@ -17,24 +17,28 @@ This theme adds a data layer for SANITY.io on top of `gatsby-theme-catalyst-core
 
 ## Theme Options
 
-| Option                   | Values  | Description                                                                                                                                |
-| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| sanityProjectId          | String  | Required, Sanity project ID                                                                                                                |
-| sanityDataset            | String  | Defaults to "production", change to reflect the dataset name you are using in Sanity                                                       |
-| sanityToken              | String  | Defaults to null, should only be used with env variables for security purposes.                                                            |
-| sanityWatchMode          | Boolean | Defaults to true, toggle for watch mode                                                                                                    |
-| sanityOverlayDrafts      | Boolean | Defaults to false, toggle for live previews, a token and private dataset is required.                                                      |
-| sanityCreatePages        | Boolean | Defaults to true, toggle to turn on/off page generation from SANITY.io.                                                                    |
-| sanityCreatePosts        | Boolean | Defaults to true, toggle to turn on/off blog post page generation from SANITY.io.                                                          |
-| sanityCreateCategories   | Boolean | Defaults to true, toggle to turn on/off category page generation from SANITY.io.                                                           |
-| sanityCreatePostsList    | Boolean | Defaults to true, toggle to turn on/off blog post list generation from SANITY.io.                                                          |
-| sanityCreateProjects     | Boolean | Defaults to true, toggle to turn on/off project page generation from SANITY.io.                                                            |
-| sanityCreateProjectsList | Boolean | Defaults to true, toggle to turn on/off project list generation from SANITY.io.                                                            |
-| sanityPostPath           | String  | Defaults to "/posts", is the path for before posts, e.g. site.com/posts/post-1.                                                            |
-| sanityPostListPath       | String  | Defaults to "/posts", is the path for the posts list, e.g. site.com/posts/.                                                                |
-| sanityProjectPath        | String  | Defaults to "/projects", is the path for before projects, e.g. site.com/projects/post-1.                                                   |
-| sanityProjectListPath    | String  | Defaults to "/projects", is the path for the projects list page, e.g. site.com/projects/.                                                  |
-| useSanityTheme           | Boolean | Experimental. Enables merging the theme-ui theme specification from SANITY.io allowing use of a GUI to change the site theme, e.g. colors. |
+| Option                        | Values  | Description                                                                                                                                |
+| ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| sanityProjectId               | String  | Required, Sanity project ID                                                                                                                |
+| sanityDataset                 | String  | Defaults to "production", change to reflect the dataset name you are using in Sanity                                                       |
+| sanityToken                   | String  | Defaults to null, should only be used with env variables for security purposes.                                                            |
+| sanityWatchMode               | Boolean | Defaults to true, toggle for watch mode                                                                                                    |
+| sanityOverlayDrafts           | Boolean | Defaults to false, toggle for live previews, a token and private dataset is required.                                                      |
+| sanityCreatePages             | Boolean | Defaults to true, toggle to turn on/off page generation from SANITY.io.                                                                    |
+| sanityCreatePosts             | Boolean | Defaults to true, toggle to turn on/off blog post page generation from SANITY.io.                                                          |
+| sanityCreateCategories        | Boolean | Defaults to true, toggle to turn on/off category page generation from SANITY.io.                                                           |
+| sanityCreatePostsList         | Boolean | Defaults to true, toggle to turn on/off blog post list generation from SANITY.io.                                                          |
+| sanityCreateProjects          | Boolean | Defaults to true, toggle to turn on/off project page generation from SANITY.io.                                                            |
+| sanityCreateProjectsList      | Boolean | Defaults to true, toggle to turn on/off project list generation from SANITY.io.                                                            |
+| sanityPostPath                | String  | Defaults to "/posts", is the path for before posts, e.g. site.com/posts/post-1.                                                            |
+| sanityPostListPath            | String  | Defaults to "/posts", is the path for the posts list, e.g. site.com/posts/.                                                                |
+| sanityProjectPath             | String  | Defaults to "/projects", is the path for before projects, e.g. site.com/projects/post-1.                                                   |
+| sanityProjectListPath         | String  | Defaults to "/projects", is the path for the projects list page, e.g. site.com/projects/.                                                  |
+| sanityPostListTitle           | String  | Defaults to "Posts", is title for the posts list page.                                                                                     |
+| sanityProjectListTitle        | String  | Defaults to "Projects", is title for the projects list page.                                                                               |
+| sanityDisplayPostListTitle    | Boolean | Defaults to true, toggle to turn on/off the post list title.io.                                                                            |
+| sanityDisplayProjectListTitle | Boolean | Defaults to true, toggle to turn on/off the project list title.io.                                                                         |
+| useSanityTheme                | Boolean | Experimental. Enables merging the theme-ui theme specification from SANITY.io allowing use of a GUI to change the site theme, e.g. colors. |
 
 ## Sanity Studio
 


### PR DESCRIPTION
Most theme values are added to the graphQL node. This removes sanityProjectId, sanityDataset, sanityToken, sanityOverlayDrafts, and sanityWatchmode from the configuration node for security purposes. This is not publicly available but I was concerned it could be exposed too easily and hence am removing those. You should only be using ENV variables for that data, especially the Token.

- all removes the long deprecated `mobileMenuBreakpoint` which I noticed was mistakenly left in.