### PR TITLE
(all): fix invertSiteLogo

### DIFF
--- a/sanity-templates/sanity-template-catalyst/template/web/gatsby-config.js
+++ b/sanity-templates/sanity-template-catalyst/template/web/gatsby-config.js
@@ -41,7 +41,7 @@ module.exports = {
         // displaySiteTitle: true,
         // displaySiteLogoMobile: true,
         // displaySiteTitleMobile: true,
-        // invertLogo: false,
+        // invertSiteLogo: false,
         // useStickyHeader: false,
         // useSocialLinks: true,
         // useColorMode: true,

--- a/starters/gatsby-starter-catalyst-blog/gatsby-config.js
+++ b/starters/gatsby-starter-catalyst-blog/gatsby-config.js
@@ -68,7 +68,7 @@ module.exports = {
         // displaySiteTitle: true,
         // displaySiteLogoMobile: true,
         // displaySiteTitleMobile: true,
-        // invertLogo: false,
+        // invertSiteLogo: false,
         // useStickyHeader: false,
         // useSocialLinks: true,
         // useColorMode: true,

--- a/starters/gatsby-starter-catalyst-core/gatsby-config.js
+++ b/starters/gatsby-starter-catalyst-core/gatsby-config.js
@@ -51,7 +51,7 @@ module.exports = {
         // displaySiteTitle: true,
         // displaySiteLogoMobile: true,
         // displaySiteTitleMobile: true,
-        // invertLogo: false,
+        // invertSiteLogo: false,
         // useStickyHeader: false,
         // useSocialLinks: true,
         // useColorMode: true,

--- a/starters/gatsby-starter-catalyst-sanity/gatsby-config.js
+++ b/starters/gatsby-starter-catalyst-sanity/gatsby-config.js
@@ -41,7 +41,7 @@ module.exports = {
         // displaySiteTitle: true,
         // displaySiteLogoMobile: true,
         // displaySiteTitleMobile: true,
-        // invertLogo: false,
+        // invertSiteLogo: false,
         // useStickyHeader: false,
         // useSocialLinks: true,
         // useColorMode: true,

--- a/starters/gatsby-starter-catalyst/gatsby-config.js
+++ b/starters/gatsby-starter-catalyst/gatsby-config.js
@@ -72,7 +72,7 @@ module.exports = {
         // displaySiteTitle: true,
         // displaySiteLogoMobile: true,
         // displaySiteTitleMobile: true,
-        // invertLogo: false,
+        // invertSiteLogo: false,
         // useStickyHeader: false,
         // useSocialLinks: true,
         // useColorMode: true,

--- a/themes/gatsby-theme-catalyst-bery/README.md
+++ b/themes/gatsby-theme-catalyst-bery/README.md
@@ -117,7 +117,7 @@ _Note that many of these options will not work with catalyst-bery but are still 
 | `displaySiteLogoMobile`  | true or false                             | Defaults to true, controls whether the logo is displayed at the mobile breakpoint           |
 | `displaySiteTitle`       | true or false                             | Defaults to true, controls whether the site title is displayed                              |
 | `displaySiteTitleMobile` | true or false                             | Defaults to true, controls whether the site title is displayed at the mobile breakpoint     |
-| `invertLogo`             | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
+| `invertSiteLogo`         | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
 | `useStickyHeader`        | true or false                             | Defaults to false, controls whether the header is sticky or static                          |
 | `useSocialLinks`         | true or false                             | Defaults to true, controls whether the social links are displayed or not                    |
 | `useColorMode`           | true or false                             | Defaults to true, controls whether the dark mode toggle is available.                       |

--- a/themes/gatsby-theme-catalyst-bery/gatsby-config.js
+++ b/themes/gatsby-theme-catalyst-bery/gatsby-config.js
@@ -10,7 +10,7 @@ module.exports = (themeOptions) => {
           displaySiteTitle: themeOptions.displaySiteTitle,
           displaySiteLogoMobile: themeOptions.displaySiteLogoMobile,
           displaySiteTitleMobile: themeOptions.displaySiteTitleMobile,
-          invertLogo: themeOptions.invertLogo,
+          invertSiteLogo: themeOptions.invertSiteLogo,
           useStickyHeader: themeOptions.useStickyHeader,
           useSocialLinks: themeOptions.useSocialLinks,
           useColorMode: themeOptions.useColorMode,

--- a/themes/gatsby-theme-catalyst-core/README.md
+++ b/themes/gatsby-theme-catalyst-core/README.md
@@ -20,7 +20,7 @@ This acts as a core theme on which all other themes are based. It houses a basic
 | `displaySiteLogoMobile`  | true or false                             | Defaults to true, controls whether the logo is displayed at the mobile breakpoint           |
 | `displaySiteTitle`       | true or false                             | Defaults to true, controls whether the site title is displayed                              |
 | `displaySiteTitleMobile` | true or false                             | Defaults to true, controls whether the site title is displayed at the mobile breakpoint     |
-| `invertLogo`             | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
+| `invertSiteLogo`         | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
 | `useStickyHeader`        | true or false                             | Defaults to false, controls whether the header is sticky or static                          |
 | `useSocialLinks`         | true or false                             | Defaults to true, controls whether the social links are displayed or not                    |
 | `useColorMode`           | true or false                             | Defaults to true, controls whether the dark mode toggle is available.                       |
@@ -36,7 +36,7 @@ Example Config:
       options: {
         displaySiteLogo: true,
         displaySiteTitle: true,
-        invertLogo: true,
+        invertSiteLogo: true,
         useStickyHeader: true,
       }
     }

--- a/themes/gatsby-theme-catalyst-ecommerce/gatsby-config.js
+++ b/themes/gatsby-theme-catalyst-ecommerce/gatsby-config.js
@@ -10,7 +10,7 @@ module.exports = (themeOptions) => {
           displaySiteTitle: themeOptions.displaySiteTitle,
           displaySiteLogoMobile: themeOptions.displaySiteLogoMobile || false,
           displaySiteTitleMobile: themeOptions.displaySiteTitleMobile,
-          invertLogo: themeOptions.invertLogo,
+          invertSiteLogo: themeOptions.invertSiteLogo,
           useStickyHeader: themeOptions.useStickyHeader,
           useSocialLinks: themeOptions.useSocialLinks,
           useColorMode: themeOptions.useColorMode || false,

--- a/themes/gatsby-theme-catalyst-helium/README.md
+++ b/themes/gatsby-theme-catalyst-helium/README.md
@@ -88,7 +88,7 @@ For example the following config is valid:
 | `displaySiteLogoMobile`  | true or false                             | Defaults to true, controls whether the logo is displayed at the mobile breakpoint           |
 | `displaySiteTitle`       | true or false                             | Defaults to true, controls whether the site title is displayed                              |
 | `displaySiteTitleMobile` | true or false                             | Defaults to true, controls whether the site title is displayed at the mobile breakpoint     |
-| `invertLogo`             | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
+| `invertSiteLogo`         | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
 | `useStickyHeader`        | true or false                             | Defaults to false, controls whether the header is sticky or static                          |
 | `useSocialLinks`         | true or false                             | Defaults to true, controls whether the social links are displayed or not                    |
 | `useColorMode`           | true or false                             | Defaults to true, controls whether the dark mode toggle is available.                       |

--- a/themes/gatsby-theme-catalyst-helium/gatsby-config.js
+++ b/themes/gatsby-theme-catalyst-helium/gatsby-config.js
@@ -10,7 +10,7 @@ module.exports = (themeOptions) => {
           displaySiteTitle: themeOptions.displaySiteTitle,
           displaySiteLogoMobile: themeOptions.displaySiteLogoMobile,
           displaySiteTitleMobile: themeOptions.displaySiteTitleMobile,
-          invertLogo: themeOptions.invertLogo,
+          invertSiteLogo: themeOptions.invertSiteLogo,
           useStickyHeader: themeOptions.useStickyHeader,
           useSocialLinks: themeOptions.useSocialLinks,
           useColorMode: themeOptions.useColorMode,

--- a/themes/gatsby-theme-catalyst-hydrogen/README.md
+++ b/themes/gatsby-theme-catalyst-hydrogen/README.md
@@ -29,7 +29,7 @@ For example the following config is valid:
       resolve: `gatsby-theme-catalyst-hydrogen`,
       options: {
         // Core theme
-        invertLogo: false,
+        invertSiteLogo: false,
         footerContentLocation: "right",
         useStickyHeader: true,
         // Sanity theme
@@ -47,7 +47,7 @@ For example the following config is valid:
 | `assetPath`        | String        | Defaults to "content/assets", determines where the page assets like images are located. |
 | `displaySiteLogo`  | true or false | Defaults to true, controls whether the logo is displayed                                |
 | `displaySiteTitle` | true or false | Defaults to true, controls whether the site title is displayed                          |
-| `invertLogo`       | true or false | Defaults to false, controls whether the logo is inverted when the mobile menu is open   |
+| `invertSiteLogo`   | true or false | Defaults to false, controls whether the logo is inverted when the mobile menu is open   |
 | `useStickyHeader`  | true or false | Defaults to false, controls whether the header is sticky or static                      |
 | `useSocialLinks`   | true or false | Defaults to true, controls whether the social links are displayed or not                |
 | `useColorMode`     | true or false | Defaults to true, controls whether the dark mode toggle is available.                   |

--- a/themes/gatsby-theme-catalyst-hydrogen/gatsby-config.js
+++ b/themes/gatsby-theme-catalyst-hydrogen/gatsby-config.js
@@ -10,7 +10,7 @@ module.exports = (themeOptions) => {
           displaySiteTitle: themeOptions.displaySiteTitle,
           displaySiteLogoMobile: themeOptions.displaySiteLogoMobile || false,
           displaySiteTitleMobile: themeOptions.displaySiteTitleMobile,
-          invertLogo: themeOptions.invertLogo,
+          invertSiteLogo: themeOptions.invertSiteLogo,
           useStickyHeader: themeOptions.useStickyHeader,
           useSocialLinks: themeOptions.useSocialLinks,
           useColorMode: themeOptions.useColorMode || false,

--- a/themes/gatsby-theme-catalyst-lithium/README.md
+++ b/themes/gatsby-theme-catalyst-lithium/README.md
@@ -80,7 +80,7 @@ For example the following config is valid:
 | `displaySiteLogoMobile`  | true or false                             | Defaults to true, controls whether the logo is displayed at the mobile breakpoint           |
 | `displaySiteTitle`       | true or false                             | Defaults to true, controls whether the site title is displayed                              |
 | `displaySiteTitleMobile` | true or false                             | Defaults to true, controls whether the site title is displayed at the mobile breakpoint     |
-| `invertLogo`             | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
+| `invertSiteLogo`         | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
 | `useStickyHeader`        | true or false                             | Defaults to false, controls whether the header is sticky or static                          |
 | `useSocialLinks`         | true or false                             | Defaults to true, controls whether the social links are displayed or not                    |
 | `useColorMode`           | true or false                             | Defaults to true, controls whether the dark mode toggle is available.                       |

--- a/themes/gatsby-theme-catalyst-lithium/gatsby-config.js
+++ b/themes/gatsby-theme-catalyst-lithium/gatsby-config.js
@@ -10,7 +10,7 @@ module.exports = (themeOptions) => {
           displaySiteTitle: themeOptions.displaySiteTitle,
           displaySiteLogoMobile: themeOptions.displaySiteLogoMobile,
           displaySiteTitleMobile: themeOptions.displaySiteTitleMobile,
-          invertLogo: themeOptions.invertLogo,
+          invertSiteLogo: themeOptions.invertSiteLogo,
           useStickyHeader: themeOptions.useStickyHeader,
           useSocialLinks: themeOptions.useSocialLinks,
           useColorMode: themeOptions.useColorMode,

--- a/www/content/docs/docs/gatsby-theme-catalyst-bery.mdx
+++ b/www/content/docs/docs/gatsby-theme-catalyst-bery.mdx
@@ -123,7 +123,7 @@ _Note that many of these options will not work with catalyst-bery but are still 
 | `displaySiteLogoMobile`  | true or false                             | Defaults to true, controls whether the logo is displayed at the mobile breakpoint           |
 | `displaySiteTitle`       | true or false                             | Defaults to true, controls whether the site title is displayed                              |
 | `displaySiteTitleMobile` | true or false                             | Defaults to true, controls whether the site title is displayed at the mobile breakpoint     |
-| `invertLogo`             | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
+| `invertSiteLogo`         | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
 | `useStickyHeader`        | true or false                             | Defaults to false, controls whether the header is sticky or static                          |
 | `useSocialLinks`         | true or false                             | Defaults to true, controls whether the social links are displayed or not                    |
 | `useColorMode`           | true or false                             | Defaults to true, controls whether the dark mode toggle is available.                       |

--- a/www/content/docs/docs/gatsby-theme-catalyst-core.mdx
+++ b/www/content/docs/docs/gatsby-theme-catalyst-core.mdx
@@ -25,7 +25,7 @@ This acts as a core theme on which all other themes are based. It houses a basic
 | `displaySiteLogoMobile`  | true or false                             | Defaults to true, controls whether the logo is displayed at the mobile breakpoint           |
 | `displaySiteTitle`       | true or false                             | Defaults to true, controls whether the site title is displayed                              |
 | `displaySiteTitleMobile` | true or false                             | Defaults to true, controls whether the site title is displayed at the mobile breakpoint     |
-| `invertLogo`             | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
+| `invertSiteLogo`         | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
 | `useStickyHeader`        | true or false                             | Defaults to false, controls whether the header is sticky or static                          |
 | `useSocialLinks`         | true or false                             | Defaults to true, controls whether the social links are displayed or not                    |
 | `useColorMode`           | true or false                             | Defaults to true, controls whether the dark mode toggle is available.                       |
@@ -41,7 +41,7 @@ Example Config:
       options: {
         displaySiteLogo: true,
         displaySiteTitle: true,
-        invertLogo: true,
+        invertSiteLogo: true,
         useStickyHeader: true,
       }
     }

--- a/www/content/docs/docs/gatsby-theme-catalyst-helium.mdx
+++ b/www/content/docs/docs/gatsby-theme-catalyst-helium.mdx
@@ -86,7 +86,7 @@ For example the following config is valid:
 | `displaySiteLogoMobile`  | true or false                             | Defaults to true, controls whether the logo is displayed at the mobile breakpoint           |
 | `displaySiteTitle`       | true or false                             | Defaults to true, controls whether the site title is displayed                              |
 | `displaySiteTitleMobile` | true or false                             | Defaults to true, controls whether the site title is displayed at the mobile breakpoint     |
-| `invertLogo`             | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
+| `invertSiteLogo`         | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
 | `useStickyHeader`        | true or false                             | Defaults to false, controls whether the header is sticky or static                          |
 | `useSocialLinks`         | true or false                             | Defaults to true, controls whether the social links are displayed or not                    |
 | `useColorMode`           | true or false                             | Defaults to true, controls whether the dark mode toggle is available.                       |

--- a/www/content/docs/docs/gatsby-theme-catalyst-lithium.mdx
+++ b/www/content/docs/docs/gatsby-theme-catalyst-lithium.mdx
@@ -86,7 +86,7 @@ For example the following config is valid:
 | `displaySiteLogoMobile`  | true or false                             | Defaults to true, controls whether the logo is displayed at the mobile breakpoint           |
 | `displaySiteTitle`       | true or false                             | Defaults to true, controls whether the site title is displayed                              |
 | `displaySiteTitleMobile` | true or false                             | Defaults to true, controls whether the site title is displayed at the mobile breakpoint     |
-| `invertLogo`             | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
+| `invertSiteLogo`         | true or false                             | Defaults to false, controls whether the logo is inverted when the mobile menu is open       |
 | `useStickyHeader`        | true or false                             | Defaults to false, controls whether the header is sticky or static                          |
 | `useSocialLinks`         | true or false                             | Defaults to true, controls whether the social links are displayed or not                    |
 | `useColorMode`           | true or false                             | Defaults to true, controls whether the dark mode toggle is available.                       |

--- a/www/content/docs/docs/getting-started.mdx
+++ b/www/content/docs/docs/getting-started.mdx
@@ -78,7 +78,7 @@ Yes you are!
     // displaySiteTitle: true,
     // displaySiteLogoMobile: true,
     // displaySiteTitleMobile: true,
-    // invertLogo: false,
+    // invertSiteLogo: false,
     // useStickyHeader: false,
     // useSocialLinks: true,
     // useColorMode: true,

--- a/www/content/docs/docs/theme-options.mdx
+++ b/www/content/docs/docs/theme-options.mdx
@@ -20,7 +20,7 @@ For example:
         // displaySiteTitle: true,
         // displaySiteLogoMobile: true,
         // displaySiteTitleMobile: true,
-        // invertLogo: false,
+        // invertSiteLogo: false,
         // useStickyHeader: false,
         // useSocialLinks: true,
         // useColorMode: true,

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -229,7 +229,7 @@ module.exports = {
         // displaySiteTitle: true,
         // displaySiteLogoMobile: true,
         displaySiteTitleMobile: false,
-        // invertLogo: false,
+        // invertSiteLogo: false,
         // useStickyHeader: false,
         // useSocialLinks: true,
         // useColorMode: true,


### PR DESCRIPTION
There was mixed messaging with both `invertLogo` and `invertSiteLogo`. 

`invertSiteLogo` is correct and always has been - given this is a bit off an eccentric theme option I don't think anyone ran into this issue but I am fixing it.