### PR TITLE
(sanity): fix missing graphql config options

### DIFF
--- a/themes/gatsby-theme-catalyst-sanity/gatsby-node.js
+++ b/themes/gatsby-theme-catalyst-sanity/gatsby-node.js
@@ -375,6 +375,8 @@ exports.createPages = async ({ graphql, actions, reporter }, themeOptions) => {
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions
   createTypes(`type CatalystSanityConfig implements Node {
+    sanityProjectId: String!
+    sanityDataset: String!
     sanityCreatePages: Boolean!
     sanityCreatePosts: Boolean!
     sanityCreatePostsList: Boolean!
@@ -396,6 +398,8 @@ exports.createSchemaCustomization = ({ actions }) => {
 exports.sourceNodes = (
   { actions: { createNode }, schema },
   {
+    sanityProjectId = "abc123",
+    sanityDataset = "production",
     sanityCreatePages = true,
     sanityCreatePosts = true,
     sanityCreatePostsList = true,
@@ -415,6 +419,8 @@ exports.sourceNodes = (
 ) => {
   // create garden data from plugin config
   const catalystSanityConfigFieldData = {
+    sanityProjectId,
+    sanityDataset,
     sanityCreatePages,
     sanityCreatePosts,
     sanityCreatePostsList,

--- a/themes/gatsby-theme-catalyst-sanity/src/components/sanity/use-sanity-config.js
+++ b/themes/gatsby-theme-catalyst-sanity/src/components/sanity/use-sanity-config.js
@@ -4,6 +4,8 @@ export const useSanityConfig = () => {
     graphql`
       query {
         catalystSanityConfig {
+          sanityProjectId
+          sanityDataset
           sanityCreatePages
           sanityCreatePosts
           sanityCreatePostsList


### PR DESCRIPTION
- I removed sanityProjectId and sanityDataset from the graphql config, this was a mistake. Added back in.