### PR TITLE
(core): Fix incorrect to plugin option for gatsby-plugin-sharp

### DIFF
--- a/themes/gatsby-theme-catalyst-core/gatsby-config.js
+++ b/themes/gatsby-theme-catalyst-core/gatsby-config.js
@@ -125,7 +125,7 @@ module.exports = (themeOptions) => {
       {
         resolve: `gatsby-plugin-sharp`,
         options: {
-          quality: imageQuality,
+          defaultQuality: imageQuality,
         },
       },
       `gatsby-plugin-catch-links`,


### PR DESCRIPTION
Mistakenly used `quality` instead of `defaultQuality`