### PR TITLE
(bery): fix post preview in SANITY studio

### DIFF
--- a/sanity-templates/sanity-template-bery/template/studio/schemas/post.js
+++ b/sanity-templates/sanity-template-bery/template/studio/schemas/post.js
@@ -76,9 +76,10 @@ export default {
     },
     prepare(selection) {
       const { title, date, featuredImage } = selection
+      const formattedDate = new Date(date).toDateString()
       return {
         title: title,
-        subtitle: format(date, "MMMM D, YYYY"), // YYYY-MM-DD --> YYYY
+        subtitle: formattedDate,
         media: featuredImage,
       }
     },

--- a/starters/gatsby-starter-catalyst-bery/sanity-studio/schemas/post.js
+++ b/starters/gatsby-starter-catalyst-bery/sanity-studio/schemas/post.js
@@ -1,5 +1,3 @@
-import { format } from "date-fns"
-
 export default {
   name: "post",
   title: "Post",
@@ -76,9 +74,10 @@ export default {
     },
     prepare(selection) {
       const { title, date, featuredImage } = selection
+      const formattedDate = new Date(date).toDateString()
       return {
         title: title,
-        subtitle: format(date, "MMMM D, YYYY"), // YYYY-MM-DD --> YYYY
+        subtitle: formattedDate,
         media: featuredImage,
       }
     },


### PR DESCRIPTION
- fixes broken date field which was causing the posts to all display with an "untitled" title in the SANITY studio despite appearing fine on the frontend.