### PR TITLE
(blog): add support for published boolean

### DIFF
--- a/.changeset/shaggy-years-sit.md
+++ b/.changeset/shaggy-years-sit.md
@@ -1,0 +1,26 @@
+---
+"gatsby-starter-catalyst-blog": patch
+"gatsby-starter-catalyst-helium": patch
+"gatsby-starter-catalyst-lithium": patch
+"gatsby-theme-catalyst-blog": patch
+"gatsby-theme-catalyst-helium": patch
+"gatsby-theme-catalyst-lithium": patch
+"gatsby-catalyst-docs": patch
+"gatsby-starter-catalyst": patch
+"gatsby-starter-catalyst-bery": patch
+"gatsby-starter-catalyst-core": patch
+"gatsby-starter-catalyst-hydrogen": patch
+"gatsby-starter-catalyst-sanity": patch
+"gatsby-starter-catalyst-stripe": patch
+"gatsby-theme-catalyst-bery": patch
+"gatsby-theme-catalyst-core": patch
+"gatsby-theme-catalyst-footer": patch
+"gatsby-theme-catalyst-header-bigtop": patch
+"gatsby-theme-catalyst-header-side": patch
+"gatsby-theme-catalyst-header-top": patch
+"gatsby-theme-catalyst-hydrogen": patch
+"gatsby-theme-catalyst-sanity": patch
+"gatsby-theme-catalyst-stripe": patch
+---
+
+Adds support for `published: true` boolean to MDX frontmatter. This flag is now required for blog posts to be published. Prevents accidentally publishing blog posts.

--- a/starters/gatsby-starter-catalyst-blog/content/posts/hello-earth.mdx
+++ b/starters/gatsby-starter-catalyst-blog/content/posts/hello-earth.mdx
@@ -1,6 +1,7 @@
 ---
 title: Hello Earth!
 date: 2019-01-15
+published: true
 ---
 
 Bacon ipsum dolor amet pig spare ribs kevin sirloin brisket porchetta. Jowl leberkas sausage ribeye, filet mignon buffalo pork beef ribs pork belly. Tri-tip strip steak rump kevin pork chop salami turducken short loin cupim hamburger. Kevin pork biltong boudin doner pancetta flank fatback strip steak. Biltong tongue cupim prosciutto. Filet mignon meatball rump, kevin shankle beef ribs bresaola t-bone corned beef cow pork belly.

--- a/starters/gatsby-starter-catalyst-blog/content/posts/hello-jupiter.mdx
+++ b/starters/gatsby-starter-catalyst-blog/content/posts/hello-jupiter.mdx
@@ -1,6 +1,7 @@
 ---
 title: Hello Jupiter
 date: 2019-03-15
+published: true
 ---
 
 Snow swab gabion loaded to the gunwalls rope's end hail-shot clap of thunder Buccaneer bilge water coxswain. Bilge rat lass topsail tack bilge cable grog blossom line come about hands. Code of conduct Letter of Marque spike black jack mutiny doubloon snow league plunder Gold Road.

--- a/starters/gatsby-starter-catalyst-blog/content/posts/hello-mars.mdx
+++ b/starters/gatsby-starter-catalyst-blog/content/posts/hello-mars.mdx
@@ -1,6 +1,7 @@
 ---
 title: Hello Mars!
 date: 2019-02-15
+published: true
 ---
 
 Shred all toilet paper and spread around the house under the bed, yet plop down in the middle where everybody walks shake treat bag my left donut is missing, as is my right hack up furballs i is not fat, i is fluffy.

--- a/starters/gatsby-starter-catalyst-helium/content/posts/5-tips-for-space-travel-success.mdx
+++ b/starters/gatsby-starter-catalyst-helium/content/posts/5-tips-for-space-travel-success.mdx
@@ -8,6 +8,7 @@ categories: [Space]
 featuredImage: ../assets/space-1.jpg
 socialImage: ../assets/helium-social.jpg
 featuredImageCaption: Photo by Guillermo Ferla
+published: true
 ---
 
 Bacon ipsum dolor amet pig spare ribs kevin sirloin brisket porchetta. Jowl leberkas sausage ribeye, filet mignon buffalo pork beef ribs pork belly. Tri-tip strip steak rump kevin pork chop salami turducken short loin cupim hamburger. Kevin pork biltong boudin doner pancetta flank fatback strip steak. Biltong tongue cupim prosciutto. Filet mignon meatball rump, kevin shankle beef ribs bresaola t-bone corned beef cow pork belly.

--- a/starters/gatsby-starter-catalyst-helium/content/posts/how-we-will-one-day-colonize-the-sun.mdx
+++ b/starters/gatsby-starter-catalyst-helium/content/posts/how-we-will-one-day-colonize-the-sun.mdx
@@ -8,6 +8,7 @@ categories: [Space]
 featuredImage: ../assets/space-2.jpg
 socialImage: ../assets/helium-social.jpg
 featuredImageCaption: Photo by NASA
+published: true
 ---
 
 Bacon ipsum dolor amet pig spare ribs kevin sirloin brisket porchetta. Jowl leberkas sausage ribeye, filet mignon buffalo pork beef ribs pork belly. Tri-tip strip steak rump kevin pork chop salami turducken short loin cupim hamburger. Kevin pork biltong boudin doner pancetta flank fatback strip steak. Biltong tongue cupim prosciutto. Filet mignon meatball rump, kevin shankle beef ribs bresaola t-bone corned beef cow pork belly.

--- a/starters/gatsby-starter-catalyst-helium/content/posts/how-you-should-pack-for-space-travel.mdx
+++ b/starters/gatsby-starter-catalyst-helium/content/posts/how-you-should-pack-for-space-travel.mdx
@@ -8,6 +8,7 @@ categories: [Space]
 featuredImage: ../assets/space-3.jpg
 socialImage: ../assets/helium-social.jpg
 featuredImageCaption: Photo by NASA
+published: true
 ---
 
 Shred all toilet paper and spread around the house under the bed, yet plop down in the middle where everybody walks shake treat bag my left donut is missing, as is my right hack up furballs i is not fat, i is fluffy.

--- a/starters/gatsby-starter-catalyst-helium/content/posts/rocket-ship-design-for-beginners.mdx
+++ b/starters/gatsby-starter-catalyst-helium/content/posts/rocket-ship-design-for-beginners.mdx
@@ -8,6 +8,7 @@ categories: [Rockets]
 featuredImage: ../assets/space-4.jpg
 socialImage: ../assets/helium-social.jpg
 featuredImageCaption: Photo by Adam Miller
+published: true
 ---
 
 Snow swab gabion loaded to the gunwalls rope's end hail-shot clap of thunder Buccaneer bilge water coxswain. Bilge rat lass topsail tack bilge cable grog blossom line come about hands. Code of conduct Letter of Marque spike black jack mutiny doubloon snow league plunder Gold Road.

--- a/starters/gatsby-starter-catalyst-helium/content/posts/space-is-not-the-final-frontier.mdx
+++ b/starters/gatsby-starter-catalyst-helium/content/posts/space-is-not-the-final-frontier.mdx
@@ -8,6 +8,7 @@ categories: [Space]
 featuredImage: ../assets/space-5.jpg
 socialImage: ../assets/helium-social.jpg
 featuredImageCaption: Photo by NASA
+published: true
 ---
 
 Shred all toilet paper and spread around the house under the bed, yet plop down in the middle where everybody walks shake treat bag my left donut is missing, as is my right hack up furballs i is not fat, i is fluffy.

--- a/starters/gatsby-starter-catalyst-helium/content/posts/the-food-you-will-like-best-in-space.mdx
+++ b/starters/gatsby-starter-catalyst-helium/content/posts/the-food-you-will-like-best-in-space.mdx
@@ -8,6 +8,7 @@ categories: [Food]
 featuredImage: ../assets/space-8.jpg
 socialImage: ../assets/helium-social.jpg
 featuredImageCaption: Photo by NASA
+published: true
 ---
 
 Shred all toilet paper and spread around the house under the bed, yet plop down in the middle where everybody walks shake treat bag my left donut is missing, as is my right hack up furballs i is not fat, i is fluffy.

--- a/starters/gatsby-starter-catalyst-helium/content/posts/what-to-do-when-things-go-wrong-during-a-rocket-launch.mdx
+++ b/starters/gatsby-starter-catalyst-helium/content/posts/what-to-do-when-things-go-wrong-during-a-rocket-launch.mdx
@@ -8,6 +8,7 @@ categories: [Rockets, Space]
 featuredImage: ../assets/space-7.jpg
 socialImage: ../assets/helium-social.jpg
 featuredImageCaption: Photo by Vincentiu Solomon
+published: true
 ---
 
 Snow swab gabion loaded to the gunwalls rope's end hail-shot clap of thunder Buccaneer bilge water coxswain. Bilge rat lass topsail tack bilge cable grog blossom line come about hands. Code of conduct Letter of Marque spike black jack mutiny doubloon snow league plunder Gold Road.

--- a/starters/gatsby-starter-catalyst-helium/content/posts/who-you-choose-to-go-to-space-says-a-lot-about-you.mdx
+++ b/starters/gatsby-starter-catalyst-helium/content/posts/who-you-choose-to-go-to-space-says-a-lot-about-you.mdx
@@ -8,6 +8,7 @@ categories: [Relationships, Space]
 featuredImage: ../assets/space-6.jpg
 socialImage: ../assets/helium-social.jpg
 featuredImageCaption: Photo by NASA
+published: true
 ---
 
 Snow swab gabion loaded to the gunwalls rope's end hail-shot clap of thunder Buccaneer bilge water coxswain. Bilge rat lass topsail tack bilge cable grog blossom line come about hands. Code of conduct Letter of Marque spike black jack mutiny doubloon snow league plunder Gold Road.

--- a/starters/gatsby-starter-catalyst-lithium/content/posts/5-tips-for-gardening-success.mdx
+++ b/starters/gatsby-starter-catalyst-lithium/content/posts/5-tips-for-gardening-success.mdx
@@ -5,6 +5,7 @@ categories: [Gardening]
 featuredImage: ../assets/garden-1.jpg
 socialImage: ../assets/lithium-social.jpg
 featuredImageCaption: Photo by Markus Spiske
+published: true
 ---
 
 Bacon ipsum dolor amet pig spare ribs kevin sirloin brisket porchetta. Jowl leberkas sausage ribeye, filet mignon buffalo pork beef ribs pork belly. Tri-tip strip steak rump kevin pork chop salami turducken short loin cupim hamburger. Kevin pork biltong boudin doner pancetta flank fatback strip steak. Biltong tongue cupim prosciutto. Filet mignon meatball rump, kevin shankle beef ribs bresaola t-bone corned beef cow pork belly.

--- a/starters/gatsby-starter-catalyst-lithium/content/posts/garden-design-for-beginners.mdx
+++ b/starters/gatsby-starter-catalyst-lithium/content/posts/garden-design-for-beginners.mdx
@@ -5,6 +5,7 @@ categories: [Permaculture]
 featuredImage: ../assets/garden-4.jpg
 socialImage: ../assets/lithium-social.jpg
 featuredImageCaption: Photo by Neslihan Gunaydin
+published: true
 ---
 
 Snow swab gabion loaded to the gunwalls rope's end hail-shot clap of thunder Buccaneer bilge water coxswain. Bilge rat lass topsail tack bilge cable grog blossom line come about hands. Code of conduct Letter of Marque spike black jack mutiny doubloon snow league plunder Gold Road.

--- a/starters/gatsby-starter-catalyst-lithium/content/posts/how-gardening-can-strengthen-your-relationships.mdx
+++ b/starters/gatsby-starter-catalyst-lithium/content/posts/how-gardening-can-strengthen-your-relationships.mdx
@@ -5,6 +5,7 @@ categories: [Gardening, Relationships]
 featuredImage: ../assets/garden-6.jpg
 socialImage: ../assets/lithium-social.jpg
 featuredImageCaption: Photo by Kelly Sikkema
+published: true
 ---
 
 Snow swab gabion loaded to the gunwalls rope's end hail-shot clap of thunder Buccaneer bilge water coxswain. Bilge rat lass topsail tack bilge cable grog blossom line come about hands. Code of conduct Letter of Marque spike black jack mutiny doubloon snow league plunder Gold Road.

--- a/starters/gatsby-starter-catalyst-lithium/content/posts/how-to-plant-trees-that-will-survive.mdx
+++ b/starters/gatsby-starter-catalyst-lithium/content/posts/how-to-plant-trees-that-will-survive.mdx
@@ -5,6 +5,7 @@ categories: [Gardening, Trees]
 featuredImage: ../assets/garden-2.jpg
 socialImage: ../assets/lithium-social.jpg
 featuredImageCaption: Photo by Benjamin Combs
+published: true
 ---
 
 Bacon ipsum dolor amet pig spare ribs kevin sirloin brisket porchetta. Jowl leberkas sausage ribeye, filet mignon buffalo pork beef ribs pork belly. Tri-tip strip steak rump kevin pork chop salami turducken short loin cupim hamburger. Kevin pork biltong boudin doner pancetta flank fatback strip steak. Biltong tongue cupim prosciutto. Filet mignon meatball rump, kevin shankle beef ribs bresaola t-bone corned beef cow pork belly.

--- a/starters/gatsby-starter-catalyst-lithium/content/posts/timing is everything-when-to-plant.mdx
+++ b/starters/gatsby-starter-catalyst-lithium/content/posts/timing is everything-when-to-plant.mdx
@@ -5,6 +5,7 @@ categories: [Gardening]
 featuredImage: ../assets/garden-5.jpg
 socialImage: ../assets/lithium-social.jpg
 featuredImageCaption: Photo by Francesco Gallarotti
+published: true
 ---
 
 Shred all toilet paper and spread around the house under the bed, yet plop down in the middle where everybody walks shake treat bag my left donut is missing, as is my right hack up furballs i is not fat, i is fluffy.

--- a/starters/gatsby-starter-catalyst-lithium/content/posts/what-plants-will-give-you-a-sustainable-food-source.mdx
+++ b/starters/gatsby-starter-catalyst-lithium/content/posts/what-plants-will-give-you-a-sustainable-food-source.mdx
@@ -5,6 +5,7 @@ categories: [Permaculture, Food]
 featuredImage: ../assets/garden-8.jpg
 socialImage: ../assets/lithium-social.jpg
 featuredImageCaption: Photo by Paige Cody
+published: true
 ---
 
 Shred all toilet paper and spread around the house under the bed, yet plop down in the middle where everybody walks shake treat bag my left donut is missing, as is my right hack up furballs i is not fat, i is fluffy.

--- a/starters/gatsby-starter-catalyst-lithium/content/posts/what-to-do-when-the-leaves-on-yout-plant-turn-orange.mdx
+++ b/starters/gatsby-starter-catalyst-lithium/content/posts/what-to-do-when-the-leaves-on-yout-plant-turn-orange.mdx
@@ -5,6 +5,7 @@ categories: [Gardening, Flowers]
 featuredImage: ../assets/garden-7.jpg
 socialImage: ../assets/lithium-social.jpg
 featuredImageCaption: Photo by Elaine Casap
+published: true
 ---
 
 Snow swab gabion loaded to the gunwalls rope's end hail-shot clap of thunder Buccaneer bilge water coxswain. Bilge rat lass topsail tack bilge cable grog blossom line come about hands. Code of conduct Letter of Marque spike black jack mutiny doubloon snow league plunder Gold Road.

--- a/starters/gatsby-starter-catalyst-lithium/content/posts/where-to-plant-flowers-to-attract-bees.mdx
+++ b/starters/gatsby-starter-catalyst-lithium/content/posts/where-to-plant-flowers-to-attract-bees.mdx
@@ -5,6 +5,7 @@ categories: [Gardening, Flowers]
 featuredImage: ../assets/garden-3.jpg
 socialImage: ../assets/lithium-social.jpg
 featuredImageCaption: Photo by Markus Spiske
+published: true
 ---
 
 Shred all toilet paper and spread around the house under the bed, yet plop down in the middle where everybody walks shake treat bag my left donut is missing, as is my right hack up furballs i is not fat, i is fluffy.

--- a/themes/gatsby-theme-catalyst-blog/gatsby-config.js
+++ b/themes/gatsby-theme-catalyst-blog/gatsby-config.js
@@ -43,7 +43,7 @@ module.exports = (themeOptions) => {
                   allCatalystPost(
                     sort: { fields: [date, title], order: DESC }
                     limit: 1000
-                    filter: { draft: { eq: false } }
+                    filter: {draft: {ne: true}, published: {eq: true}}
                   ) {
                     nodes {
                       id

--- a/themes/gatsby-theme-catalyst-blog/gatsby-node.js
+++ b/themes/gatsby-theme-catalyst-blog/gatsby-node.js
@@ -80,7 +80,7 @@ exports.createSchemaCustomization = ({ actions, schema }, themeOptions) => {
       socialImage: File @fileByRelativePath
       timeToRead: Int
       postType: String
-      published: Boolean
+      published: Boolean! @defaultFalse
   }`)
 
   createTypes(`type CatalystBlogConfig implements Node {
@@ -110,7 +110,8 @@ exports.createSchemaCustomization = ({ actions, schema }, themeOptions) => {
           extensions: { defaultFalse: {} },
         },
         published: {
-          type: `Boolean`,
+          type: `Boolean!`,
+          extensions: { defaultFalse: {} },
         },
         slug: {
           type: `String!`,

--- a/themes/gatsby-theme-catalyst-blog/gatsby-node.js
+++ b/themes/gatsby-theme-catalyst-blog/gatsby-node.js
@@ -80,6 +80,7 @@ exports.createSchemaCustomization = ({ actions, schema }, themeOptions) => {
       socialImage: File @fileByRelativePath
       timeToRead: Int
       postType: String
+      published: Boolean
   }`)
 
   createTypes(`type CatalystBlogConfig implements Node {
@@ -107,6 +108,9 @@ exports.createSchemaCustomization = ({ actions, schema }, themeOptions) => {
         draft: {
           type: `Boolean!`,
           extensions: { defaultFalse: {} },
+        },
+        published: {
+          type: `Boolean`,
         },
         slug: {
           type: `String!`,
@@ -207,6 +211,7 @@ exports.onCreateNode = async (
       featuredImageCaption: node.frontmatter.featuredImageCaption,
       socialImage: node.frontmatter.socialImage,
       draft: node.frontmatter.draft,
+      published: node.frontmatter.published,
       postType: node.frontmatter.postType || "article",
     }
 
@@ -249,19 +254,23 @@ exports.createPages = async ({ graphql, actions, reporter }, themeOptions) => {
       blogPosts: allCatalystPost(
         sort: { fields: [date, title], order: DESC }
         limit: 1000
-        filter: { draft: { eq: false } }
+        filter: { draft: { ne: true }, published: { eq: true } }
       ) {
         nodes {
           id
           slug
         }
       }
-      tagList: allCatalystPost(filter: { draft: { eq: false } }) {
+      tagList: allCatalystPost(
+        filter: { draft: { ne: true }, published: { eq: true } }
+      ) {
         group(field: tags) {
           fieldValue
         }
       }
-      categoryList: allCatalystPost(filter: { draft: { eq: false } }) {
+      categoryList: allCatalystPost(
+        filter: { draft: { ne: true }, published: { eq: true } }
+      ) {
         group(field: categories) {
           fieldValue
         }

--- a/themes/gatsby-theme-catalyst-blog/src/components/queries/category-list-query.js
+++ b/themes/gatsby-theme-catalyst-blog/src/components/queries/category-list-query.js
@@ -10,7 +10,7 @@ export const query = graphql`
   query {
     categoryList: allCatalystPost(
       limit: 1000
-      filter: { draft: { eq: false } }
+      filter: { draft: { ne: true }, published: { eq: true } }
     ) {
       group(field: categories) {
         fieldValue

--- a/themes/gatsby-theme-catalyst-blog/src/components/queries/category-query.js
+++ b/themes/gatsby-theme-catalyst-blog/src/components/queries/category-query.js
@@ -13,7 +13,7 @@ export const query = graphql`
     allCatalystPost(
       sort: { fields: [date, title], order: DESC }
       limit: 1000
-      filter: { draft: { eq: false }, categories: { in: [$category] } }
+      filter: { published: { eq: true }, categories: { in: [$category] } }
     ) {
       nodes {
         id

--- a/themes/gatsby-theme-catalyst-blog/src/components/queries/post-list-query.js
+++ b/themes/gatsby-theme-catalyst-blog/src/components/queries/post-list-query.js
@@ -12,7 +12,7 @@ export const query = graphql`
     allCatalystPost(
       sort: { fields: [date, title], order: DESC }
       limit: 1000
-      filter: { draft: { eq: false } }
+      filter: { draft: { ne: true }, published: { eq: true } }
     ) {
       nodes {
         id

--- a/themes/gatsby-theme-catalyst-blog/src/components/queries/tag-list-query.js
+++ b/themes/gatsby-theme-catalyst-blog/src/components/queries/tag-list-query.js
@@ -8,7 +8,10 @@ const TagListQuery = ({ data }) => {
 
 export const query = graphql`
   query {
-    tagList: allCatalystPost(limit: 1000, filter: { draft: { eq: false } }) {
+    tagList: allCatalystPost(
+      limit: 1000
+      filter: { draft: { ne: true }, published: { eq: true } }
+    ) {
       group(field: tags) {
         fieldValue
         totalCount

--- a/themes/gatsby-theme-catalyst-blog/src/components/queries/tag-query.js
+++ b/themes/gatsby-theme-catalyst-blog/src/components/queries/tag-query.js
@@ -13,7 +13,7 @@ export const query = graphql`
     allCatalystPost(
       sort: { fields: [date, title], order: DESC }
       limit: 1000
-      filter: { draft: { eq: false }, tags: { in: [$tag] } }
+      filter: { published: { eq: true }, tags: { in: [$tag] } }
     ) {
       nodes {
         id

--- a/themes/gatsby-theme-catalyst-helium/gatsby-config.js
+++ b/themes/gatsby-theme-catalyst-helium/gatsby-config.js
@@ -62,7 +62,7 @@ module.exports = (themeOptions) => {
                   allCatalystPost(
                     sort: { fields: [date, title], order: DESC }
                     limit: 1000
-                    filter: { draft: { eq: false } }
+                    filter: {draft: {ne: true}, published: {eq: true}}
                   ) {
                     nodes {
                       id

--- a/themes/gatsby-theme-catalyst-lithium/gatsby-config.js
+++ b/themes/gatsby-theme-catalyst-lithium/gatsby-config.js
@@ -62,7 +62,7 @@ module.exports = (themeOptions) => {
                   allCatalystPost(
                     sort: { fields: [date, title], order: DESC }
                     limit: 1000
-                    filter: { draft: { eq: false } }
+                    filter: {draft: {ne: true}, published: {eq: true}}
                   ) {
                     nodes {
                       id

--- a/www/content/docs/docs/gatsby-theme-catalyst-blog.mdx
+++ b/www/content/docs/docs/gatsby-theme-catalyst-blog.mdx
@@ -59,21 +59,22 @@ Example Config:
 
 The following fields are available in front matter.
 
-| Field                | Required? | Values  | Description                                              |
-| -------------------- | --------- | ------- | -------------------------------------------------------- |
-| title                | Yes       | String  | Title of the post                                        |
-| date                 | Yes       | Date    | Publication date, e.g. 2019-04-15                        |
-| subTitle             | No        | String  | Sub title or deck for blog posts                         |
-| author               | No        | String  | Author of the post                                       |
-| featuredImage        | No        | String  | Featured image to be used for the post                   |
-| featuredImageCaption | No        | String  | Caption for the featured image                           |
-| socialImage          | No        | String  | Social image to be used for the post                     |
-| slug                 | No        | String  | Optionally used to specify the link slug for the post    |
-| authorLink           | No        | String  | Used as a link for the author name in the post summaries |
-| tags                 | No        | Array   | Tags for the post, ["tag1", "tag2", "tag3"]              |
-| categories           | No        | Array   | Categories for the post, ["cats", "dogs", "snakes"]      |
-| keywords             | No        | Array   | Keywords used for Seo, ["key1", "key2", "key3"]          |
-| draft                | No        | Boolean | Defaults to false, set to true if a post is a draft      |
+| Field                | Required? | Values  | Description                                                                                                                                                           |
+| -------------------- | --------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title                | Yes       | String  | Title of the post                                                                                                                                                     |
+| date                 | Yes       | Date    | Publication date, e.g. 2019-04-15                                                                                                                                     |
+| subTitle             | No        | String  | Sub title or deck for blog posts                                                                                                                                      |
+| author               | No        | String  | Author of the post                                                                                                                                                    |
+| featuredImage        | No        | String  | Featured image to be used for the post                                                                                                                                |
+| featuredImageCaption | No        | String  | Caption for the featured image                                                                                                                                        |
+| socialImage          | No        | String  | Social image to be used for the post                                                                                                                                  |
+| slug                 | No        | String  | Optionally used to specify the link slug for the post                                                                                                                 |
+| authorLink           | No        | String  | Used as a link for the author name in the post summaries                                                                                                              |
+| tags                 | No        | Array   | Tags for the post, ["tag1", "tag2", "tag3"]                                                                                                                           |
+| categories           | No        | Array   | Categories for the post, ["cats", "dogs", "snakes"]                                                                                                                   |
+| keywords             | No        | Array   | Keywords used for Seo, ["key1", "key2", "key3"]                                                                                                                       |
+| published            | No        | Boolean | Defaults to false, set to true to publish a post.                                                                                                                     |
+| draft                | No        | Boolean | Defaults to false, if set to true a post will not publish, not required. Posts do not require this, if published is missing or set to false this has the same effect. |
 
 Example frontmatter:
 
@@ -86,7 +87,7 @@ socialImage: ../assets/post1-social.jpg
 author: Eric Howey
 authorLink: https://twitter.com/erchwy
 tags: [Wicked, Awesome, Radical]
-draft: true
 slug: /blog/custom-post-slug
+published: true
 ---
 ```

--- a/www/content/docs/docs/gatsby-theme-catalyst-helium.mdx
+++ b/www/content/docs/docs/gatsby-theme-catalyst-helium.mdx
@@ -32,6 +32,8 @@ The following fields are available in front matter.
 | categories           | Yes       | Array   | Categories for the post, ["cats", "dogs", "snakes"]   |
 | keywords             | No        | Array   | Keywords used for Seo, ["key1", "key2", "key3"]       |
 | draft                | No        | Boolean | Defaults to false, set to true if a post is a draft   |
+| draft                | No        | Boolean | Defaults to false, set to true if a post is a draft   |
+| published            | No        | Boolean | Defaults to false, set to true to publish a post.     |
 
 ## Theme options
 

--- a/www/content/docs/docs/gatsby-theme-catalyst-lithium.mdx
+++ b/www/content/docs/docs/gatsby-theme-catalyst-lithium.mdx
@@ -32,6 +32,7 @@ The following fields are available in front matter.
 | categories           | Yes       | Array   | Categories for the post, ["cats", "dogs", "snakes"]   |
 | keywords             | No        | Array   | Keywords used for Seo, ["key1", "key2", "key3"]       |
 | draft                | No        | Boolean | Defaults to false, set to true if a post is a draft   |
+| published            | No        | Boolean | Defaults to false, set to true to publish a post.     |
 
 ## Theme options
 

--- a/www/content/docs/docs/migrating.mdx
+++ b/www/content/docs/docs/migrating.mdx
@@ -51,6 +51,12 @@ In most cases, if you were using default options, this will all "just work". You
 - `footerContentLocation` and `useFooterSocialLinks` are now options for the footer theme
 - Removed options `invertLogo`, `displaySiteTitle`, `displaySiteTitleMobile`, `displaySiteLogo`, `displaySiteLogoMobile`. You can now do this all yourself completely custom in the shadowed components. See above for details.
 
+### Part 4: Published boolean
+
+This only affects `gatsby-theme-catalyst-blog` (MDX blog theme).
+
+There is now a boolean flag to publish posts. You will need to add `published: true` to your frontmatter so that the posts publish now. This prevents any accidental publishing of draft posts. If `published` is missing or false then a post will not publish. Also if a post is set to `draft: true` then a post will not publish, even if published is set to true.
+
 ### Other breaking changes
 
 These should not affect most users, but could if you were doing some advanced stuff.

--- a/www/content/docs/docs/tutorials/creating-a-blog-with-gatsby-theme-catalyst-lithium.mdx
+++ b/www/content/docs/docs/tutorials/creating-a-blog-with-gatsby-theme-catalyst-lithium.mdx
@@ -190,6 +190,7 @@ categories: [Coding]
 featuredImage: ../assets/garden-3.jpg
 socialImage: ../assets/lithium-social.jpg
 featuredImageCaption: Photo by Markus Spiske
+published: true
 ---
 
 # My first post


### PR DESCRIPTION
- MDX blog posts now require a `published: true` boolean in their frontmatter to be published. Prevents accidentally publishing blog posts
- `draft: true` will still work, and prevents a post from being published even is `published: true`. However the same effect can be achieved by leaving published blank or false.